### PR TITLE
Feat/agent recovery mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main,develop]
 
 jobs:
   test-controller:

--- a/controller/src/api/__tests__/recovery-mode.test.ts
+++ b/controller/src/api/__tests__/recovery-mode.test.ts
@@ -1,0 +1,197 @@
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { startPostgres, stopPostgres } from '../../__tests__/pg-setup.js';
+import { disableRecoveryMode, getConfig, setConfig } from '../../db/queries.js';
+import { buildTestApp, getAuthToken, teardownTestApp } from './helpers.js';
+
+describe('Recovery Mode API', () => {
+  let app: FastifyInstance;
+  let authToken: string;
+
+  beforeAll(async () => {
+    await startPostgres();
+    app = await buildTestApp();
+    authToken = await getAuthToken(app);
+  }, 60000);
+
+  afterAll(async () => {
+    await app.close();
+    await teardownTestApp();
+    await stopPostgres();
+  });
+
+  const authHeaders = () => ({ authorization: `Bearer ${authToken}` });
+
+  beforeEach(async () => {
+    await disableRecoveryMode();
+  });
+
+  // --- GET /api/recovery-mode ---
+
+  describe('GET /api/recovery-mode', () => {
+    it('returns disabled when not active', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.enabled).toBe(false);
+      expect(body.expiresAt).toBeNull();
+      expect(body.remainingSeconds).toBeNull();
+    });
+
+    it('returns enabled with countdown when active', async () => {
+      // Enable recovery mode for 5 minutes
+      await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: { ttlMinutes: 5 },
+      });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.enabled).toBe(true);
+      expect(body.expiresAt).toBeGreaterThan(Date.now());
+      expect(body.remainingSeconds).toBeGreaterThan(0);
+      expect(body.remainingSeconds).toBeLessThanOrEqual(300);
+    });
+
+    it('returns disabled when TTL has expired', async () => {
+      // Set an already-expired timestamp
+      await setConfig('recovery_mode_expires_at', String(Date.now() - 1000));
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+      });
+      const body = JSON.parse(res.body);
+      expect(body.enabled).toBe(false);
+      expect(body.expiresAt).toBeNull();
+    });
+
+    it('requires auth', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/recovery-mode',
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // --- POST /api/recovery-mode ---
+
+  describe('POST /api/recovery-mode', () => {
+    it('enables recovery mode with default TTL (15 min)', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: {},
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.enabled).toBe(true);
+      expect(body.remainingSeconds).toBe(900); // 15 * 60
+
+      // Verify in DB
+      const val = await getConfig('recovery_mode_expires_at');
+      expect(val).toBeDefined();
+      expect(Number(val)).toBeGreaterThan(Date.now());
+    });
+
+    it('enables recovery mode with custom TTL', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: { ttlMinutes: 30 },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.remainingSeconds).toBe(1800); // 30 * 60
+    });
+
+    it('rejects TTL < 1', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: { ttlMinutes: 0 },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects TTL > 60', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: { ttlMinutes: 120 },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('requires auth', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        payload: { ttlMinutes: 5 },
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+
+  // --- DELETE /api/recovery-mode ---
+
+  describe('DELETE /api/recovery-mode', () => {
+    it('disables active recovery mode', async () => {
+      // Enable first
+      await app.inject({
+        method: 'POST',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+        payload: { ttlMinutes: 15 },
+      });
+
+      // Disable
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.enabled).toBe(false);
+
+      // Verify in DB
+      const val = await getConfig('recovery_mode_expires_at');
+      expect(val).toBeUndefined();
+    });
+
+    it('is idempotent when already disabled', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/recovery-mode',
+        headers: authHeaders(),
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('requires auth', async () => {
+      const res = await app.inject({
+        method: 'DELETE',
+        url: '/api/recovery-mode',
+      });
+      expect(res.statusCode).toBe(401);
+    });
+  });
+});

--- a/controller/src/api/middleware/audit.ts
+++ b/controller/src/api/middleware/audit.ts
@@ -57,6 +57,14 @@ const AUDIT_ROUTES: Record<string, { action: string; targetType: string }> = {
     action: 'policy.update',
     targetType: 'config',
   },
+  'POST /api/recovery-mode': {
+    action: 'recovery_mode.enable',
+    targetType: 'config',
+  },
+  'DELETE /api/recovery-mode': {
+    action: 'recovery_mode.disable',
+    targetType: 'config',
+  },
 };
 
 export function registerAuditHook(fastify: FastifyInstance): void {

--- a/controller/src/api/routes/config.ts
+++ b/controller/src/api/routes/config.ts
@@ -1,8 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify';
 import cron from 'node-cron';
 import {
+  disableRecoveryMode,
+  enableRecoveryMode,
   getAllConfig,
   getEffectivePolicy,
+  getRecoveryModeExpiry,
   setConfig,
   upsertUpdatePolicy,
 } from '../../db/queries.js';
@@ -88,6 +91,38 @@ const configRoutes: FastifyPluginAsync = async (fastify) => {
       strategy: strategy ?? existing.strategy ?? 'stop-first',
     });
     return { message: 'Policy updated' };
+  });
+
+  // --- Recovery Mode ---
+
+  fastify.get('/api/recovery-mode', async () => {
+    const expiresAt = await getRecoveryModeExpiry();
+    if (!expiresAt) {
+      return { enabled: false, expiresAt: null, remainingSeconds: null };
+    }
+    return {
+      enabled: true,
+      expiresAt,
+      remainingSeconds: Math.max(0, Math.round((expiresAt - Date.now()) / 1000)),
+    };
+  });
+
+  fastify.post<{ Body: { ttlMinutes?: number } }>('/api/recovery-mode', async (request, reply) => {
+    const ttl = request.body?.ttlMinutes ?? 15;
+    if (ttl < 1 || ttl > 60) {
+      return reply.code(400).send({ error: 'TTL must be between 1 and 60 minutes' });
+    }
+    const expiresAt = await enableRecoveryMode(ttl);
+    return {
+      enabled: true,
+      expiresAt,
+      remainingSeconds: ttl * 60,
+    };
+  });
+
+  fastify.delete('/api/recovery-mode', async () => {
+    await disableRecoveryMode();
+    return { enabled: false };
   });
 };
 

--- a/controller/src/db/migrations/020-agent-recovery.sql
+++ b/controller/src/db/migrations/020-agent-recovery.sql
@@ -1,0 +1,2 @@
+-- Flag agents that were auto-registered via recovery mode
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS recovery_registered BOOLEAN DEFAULT FALSE;

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -308,6 +308,31 @@ export async function getAllConfig(): Promise<Record<string, string>> {
   return config;
 }
 
+// --- Recovery Mode ---
+
+export async function isRecoveryModeActive(): Promise<boolean> {
+  const expiresAt = await getConfig('recovery_mode_expires_at');
+  if (!expiresAt) return false;
+  return Date.now() < Number(expiresAt);
+}
+
+export async function getRecoveryModeExpiry(): Promise<number | null> {
+  const expiresAt = await getConfig('recovery_mode_expires_at');
+  if (!expiresAt) return null;
+  const ts = Number(expiresAt);
+  return Date.now() < ts ? ts : null;
+}
+
+export async function enableRecoveryMode(ttlMinutes: number): Promise<number> {
+  const expiresAt = Date.now() + ttlMinutes * 60 * 1000;
+  await setConfig('recovery_mode_expires_at', String(expiresAt));
+  return expiresAt;
+}
+
+export async function disableRecoveryMode(): Promise<void> {
+  await sql`DELETE FROM config WHERE key = 'recovery_mode_expires_at'`;
+}
+
 // --- Registry Credentials ---
 
 export interface RegistryCredential {
@@ -604,6 +629,7 @@ function mapAgent(row: Record<string, unknown>): Agent {
     arch: (row.arch as string | null) ?? null,
     agent_version: (row.agent_version as string | null) ?? null,
     created_at: Number(row.created_at),
+    recovery_registered: !!row.recovery_registered,
   };
 }
 

--- a/controller/src/ws/__tests__/hub.test.ts
+++ b/controller/src/ws/__tests__/hub.test.ts
@@ -471,6 +471,9 @@ describe('AgentHub', () => {
     it('deduplicates agents with same name in same recovery window', async () => {
       await enableRecoveryMode(5);
 
+      // Use a unique token for dedup test (different from recoveryToken)
+      const dedupToken = 'b'.repeat(64);
+
       // First connection
       const ws1 = connectAgent();
       await waitForOpen(ws1);
@@ -478,7 +481,7 @@ describe('AgentHub', () => {
         JSON.stringify({
           type: 'REGISTER',
           payload: {
-            token: recoveryToken,
+            token: dedupToken,
             hostname: 'dedup-host',
             agentName: 'dedup-agent',
             containers: [],
@@ -489,14 +492,14 @@ describe('AgentHub', () => {
       ws1.close();
       await new Promise((r) => setTimeout(r, 200));
 
-      // Second connection with same token and name
+      // Second connection with same token and name — should reuse existing agent
       const ws2 = connectAgent();
       await waitForOpen(ws2);
       ws2.send(
         JSON.stringify({
           type: 'REGISTER',
           payload: {
-            token: recoveryToken,
+            token: dedupToken,
             hostname: 'dedup-host',
             agentName: 'dedup-agent',
             containers: [],

--- a/controller/src/ws/__tests__/hub.test.ts
+++ b/controller/src/ws/__tests__/hub.test.ts
@@ -1,10 +1,17 @@
 import fastifyWebsocket from '@fastify/websocket';
 import bcrypt from 'bcryptjs';
 import Fastify, { type FastifyInstance } from 'fastify';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
 import { startPostgres, stopPostgres } from '../../__tests__/pg-setup.js';
-import { getAgent, insertAgent, setConfig } from '../../db/queries.js';
+import {
+  disableRecoveryMode,
+  enableRecoveryMode,
+  getAgent,
+  insertAgent,
+  listAgents,
+  setConfig,
+} from '../../db/queries.js';
 import { AgentHub } from '../hub.js';
 
 function waitForMessage(ws: WebSocket): Promise<Record<string, unknown>> {
@@ -378,5 +385,133 @@ describe('AgentHub', () => {
     // Map should be empty after disconnect cleanup
     await new Promise((r) => setTimeout(r, 300));
     expect(pendingMap.size).toBe(0);
+  });
+
+  // --- Recovery Mode ---
+
+  describe('Recovery Mode', () => {
+    // Valid 64-char hex token (not registered in DB)
+    const recoveryToken = 'a'.repeat(64);
+
+    afterEach(async () => {
+      await disableRecoveryMode();
+      hub.resetRecoveryCount();
+    });
+
+    it('rejects unknown token when recovery mode is OFF', async () => {
+      const ws = connectAgent();
+      await waitForOpen(ws);
+      const closePromise = waitForClose(ws);
+
+      ws.send(
+        JSON.stringify({
+          type: 'REGISTER',
+          payload: { token: recoveryToken, hostname: 'recovery-host', containers: [] },
+        }),
+      );
+
+      const { code } = await closePromise;
+      expect(code).toBe(4001);
+    });
+
+    it('auto-registers unknown agent when recovery mode is ON', async () => {
+      await enableRecoveryMode(5);
+
+      const ws = connectAgent();
+      await waitForOpen(ws);
+
+      ws.send(
+        JSON.stringify({
+          type: 'REGISTER',
+          payload: {
+            token: recoveryToken,
+            hostname: 'recovery-host',
+            agentName: 'recovered-agent',
+            containers: [],
+          },
+        }),
+      );
+
+      // Wait for registration to process
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Agent should be online
+      const agents = await listAgents();
+      const recovered = agents.find((a) => a.name === 'recovered-agent');
+      expect(recovered).toBeDefined();
+      expect(recovered!.status).toBe('online');
+      expect(recovered!.recovery_registered).toBe(true);
+
+      ws.close();
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    it('rejects non-hex tokens even in recovery mode', async () => {
+      await enableRecoveryMode(5);
+
+      const ws = connectAgent();
+      await waitForOpen(ws);
+      const closePromise = waitForClose(ws);
+
+      ws.send(
+        JSON.stringify({
+          type: 'REGISTER',
+          payload: {
+            token: 'not-a-valid-hex-token',
+            hostname: 'bad-host',
+            containers: [],
+          },
+        }),
+      );
+
+      const { code } = await closePromise;
+      expect(code).toBe(4001);
+    });
+
+    it('deduplicates agents with same name in same recovery window', async () => {
+      await enableRecoveryMode(5);
+
+      // First connection
+      const ws1 = connectAgent();
+      await waitForOpen(ws1);
+      ws1.send(
+        JSON.stringify({
+          type: 'REGISTER',
+          payload: {
+            token: recoveryToken,
+            hostname: 'dedup-host',
+            agentName: 'dedup-agent',
+            containers: [],
+          },
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 500));
+      ws1.close();
+      await new Promise((r) => setTimeout(r, 200));
+
+      // Second connection with same token and name
+      const ws2 = connectAgent();
+      await waitForOpen(ws2);
+      ws2.send(
+        JSON.stringify({
+          type: 'REGISTER',
+          payload: {
+            token: recoveryToken,
+            hostname: 'dedup-host',
+            agentName: 'dedup-agent',
+            containers: [],
+          },
+        }),
+      );
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Should reuse the same agent, not create a duplicate
+      const agents = await listAgents();
+      const matches = agents.filter((a) => a.name === 'dedup-agent');
+      expect(matches.length).toBe(1);
+
+      ws2.close();
+      await new Promise((r) => setTimeout(r, 200));
+    });
   });
 });

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -6,10 +6,12 @@ import {
   getConfig,
   getContainersByAgent,
   getEffectivePolicy,
+  insertAgent,
   insertAuditLog,
   insertScanResult,
   insertUpdateLog,
   insertUpdateLogAndDigests,
+  isRecoveryModeActive,
   listAgents,
   listAgentsByTokenPrefix,
   listRegistryCredentials,
@@ -171,7 +173,12 @@ export class AgentHub {
             }
 
             const payload = message.payload as RegisterPayload;
-            const result = await this.authenticateAgent(payload.token);
+            let result = await this.authenticateAgent(payload.token);
+
+            // Recovery mode: if normal auth fails, try auto-registering the agent
+            if (!result) {
+              result = await this.tryRecoveryRegister(payload, socket);
+            }
 
             if (!result) {
               socket.close(4001, 'Invalid token');
@@ -850,6 +857,93 @@ export class AgentHub {
       }
     }
     return null;
+  }
+
+  /** Rate limiter for recovery registrations within a single recovery window. */
+  private recoveryCount = 0;
+  private static readonly MAX_RECOVERY_PER_WINDOW = 20;
+  private static readonly VALID_TOKEN_RE = /^[0-9a-f]{64}$/;
+
+  /**
+   * Attempt to auto-register an agent via recovery mode.
+   * Only works when recovery mode is active, the token has valid format,
+   * and the per-window rate limit hasn't been exceeded.
+   */
+  private async tryRecoveryRegister(
+    payload: RegisterPayload,
+    socket: WebSocket,
+  ): Promise<{ id: string } | null> {
+    // Check token format first (cheap, no DB hit)
+    if (!AgentHub.VALID_TOKEN_RE.test(payload.token)) return null;
+
+    // Check if recovery mode is active
+    const active = await isRecoveryModeActive();
+    if (!active) return null;
+
+    // Rate limit
+    if (this.recoveryCount >= AgentHub.MAX_RECOVERY_PER_WINDOW) {
+      log.warn('hub', 'Recovery mode rate limit exceeded, rejecting registration');
+      return null;
+    }
+
+    // Dedup: check if an agent with the same name already exists (re-registration in same window)
+    const agentName = payload.agentName || payload.hostname || 'recovered-agent';
+    const existingAgents = await listAgents();
+    const duplicate = existingAgents.find((a) => a.name === agentName);
+    if (duplicate) {
+      // Try authenticating against the existing duplicate (may have been recovery-registered moments ago)
+      const valid = await bcrypt.compare(payload.token, duplicate.token_hash);
+      if (valid) return { id: duplicate.id };
+      // Different token, same name — append short ID suffix
+    }
+
+    const agentId = randomUUID();
+    const tokenHash = await bcrypt.hash(payload.token, 10);
+    const tokenPrefix = payload.token.slice(0, 8);
+    const finalName = duplicate ? `${agentName}-${agentId.slice(0, 8)}` : agentName;
+
+    await insertAgent({
+      id: agentId,
+      name: finalName,
+      hostname: payload.hostname,
+      token_hash: tokenHash,
+      token_prefix: tokenPrefix,
+    });
+
+    // Mark as recovery-registered
+    const { sql } = await import('../db/client.js');
+    await sql`UPDATE agents SET recovery_registered = TRUE WHERE id = ${agentId}`;
+
+    this.recoveryCount++;
+
+    // Audit log
+    const remoteAddr =
+      (socket as unknown as { _socket?: { remoteAddress?: string } })._socket?.remoteAddress ??
+      'unknown';
+    await insertAuditLog({
+      actor: 'system:recovery',
+      action: 'agent.recovery_register',
+      targetType: 'agent',
+      targetId: agentId,
+      details: {
+        agentName: finalName,
+        hostname: payload.hostname,
+        ip: remoteAddr,
+      },
+      ipAddress: remoteAddr,
+    });
+
+    log.info(
+      'hub',
+      `Recovery mode: auto-registered agent "${finalName}" (${agentId}) from ${remoteAddr}`,
+    );
+
+    return { id: agentId };
+  }
+
+  /** Reset recovery registration counter (call when recovery mode is enabled/disabled). */
+  resetRecoveryCount(): void {
+    this.recoveryCount = 0;
   }
 
   private async syncCredentialsToAgent(agentId: string): Promise<void> {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -16,6 +16,7 @@ export interface Agent {
   arch: string | null;
   agent_version: string | null;
   created_at: number;
+  recovery_registered?: boolean;
   containers?: Container[];
 }
 

--- a/ui/src/api/hooks/useSettings.ts
+++ b/ui/src/api/hooks/useSettings.ts
@@ -19,3 +19,39 @@ export function useUpdateConfig() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['config'] }),
   });
 }
+
+// --- Recovery Mode ---
+
+interface RecoveryModeStatus {
+  enabled: boolean;
+  expiresAt: number | null;
+  remainingSeconds: number | null;
+}
+
+export function useRecoveryMode() {
+  return useQuery({
+    queryKey: ['recovery-mode'],
+    queryFn: () => apiRequest<RecoveryModeStatus>('/recovery-mode'),
+    refetchInterval: 10_000,
+  });
+}
+
+export function useEnableRecoveryMode() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { ttlMinutes?: number }) =>
+      apiRequest<RecoveryModeStatus>('/recovery-mode', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['recovery-mode'] }),
+  });
+}
+
+export function useDisableRecoveryMode() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => apiRequest<{ enabled: false }>('/recovery-mode', { method: 'DELETE' }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['recovery-mode'] }),
+  });
+}

--- a/ui/src/components/agents/AgentCard.tsx
+++ b/ui/src/components/agents/AgentCard.tsx
@@ -28,6 +28,14 @@ export function AgentCard({ agent, checking, onCheck, onUpdate }: AgentCardProps
           <div className="flex items-center gap-2">
             <StatusDot status={agent.status} />
             <h3 className="font-semibold">{agent.name}</h3>
+            {agent.recovery_registered && (
+              <Badge
+                variant="outline"
+                className="text-[10px] px-1.5 py-0 border-orange-400/30 text-orange-500"
+              >
+                Recovery
+              </Badge>
+            )}
           </div>
           {updateCount > 0 && (
             <Badge

--- a/ui/src/components/settings/RecoveryModeCard.tsx
+++ b/ui/src/components/settings/RecoveryModeCard.tsx
@@ -1,0 +1,175 @@
+import { Shield, ShieldAlert, ShieldOff } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import {
+  useDisableRecoveryMode,
+  useEnableRecoveryMode,
+  useRecoveryMode,
+} from '@/api/hooks/useSettings';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useStore } from '@/store/useStore';
+
+const TTL_OPTIONS = [
+  { label: '5 min', value: 5 },
+  { label: '15 min', value: 15 },
+  { label: '30 min', value: 30 },
+  { label: '60 min', value: 60 },
+];
+
+export function RecoveryModeCard() {
+  const { data: status } = useRecoveryMode();
+  const enableMutation = useEnableRecoveryMode();
+  const disableMutation = useDisableRecoveryMode();
+  const addToast = useStore((s) => s.addToast);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [selectedTtl, setSelectedTtl] = useState(15);
+  const [countdown, setCountdown] = useState<number | null>(null);
+
+  // Live countdown
+  useEffect(() => {
+    if (!status?.enabled || !status.expiresAt) {
+      setCountdown(null);
+      return;
+    }
+    const tick = () => {
+      const remaining = Math.max(0, Math.round((status.expiresAt! - Date.now()) / 1000));
+      setCountdown(remaining);
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [status?.enabled, status?.expiresAt]);
+
+  const formatTime = (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  };
+
+  const handleEnable = () => {
+    enableMutation.mutate(
+      { ttlMinutes: selectedTtl },
+      {
+        onSuccess: () => {
+          setConfirmOpen(false);
+          addToast({
+            type: 'success',
+            message: `Recovery mode enabled for ${selectedTtl} minutes`,
+          });
+        },
+        onError: () => addToast({ type: 'error', message: 'Failed to enable recovery mode' }),
+      },
+    );
+  };
+
+  const handleDisable = () => {
+    disableMutation.mutate(undefined, {
+      onSuccess: () => addToast({ type: 'success', message: 'Recovery mode disabled' }),
+      onError: () => addToast({ type: 'error', message: 'Failed to disable recovery mode' }),
+    });
+  };
+
+  const isActive = status?.enabled && countdown !== null && countdown > 0;
+
+  return (
+    <>
+      <Card className={isActive ? 'border-orange-500/50' : ''}>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <CardTitle className="flex items-center gap-2">
+                {isActive ? (
+                  <ShieldAlert size={18} className="text-orange-500" />
+                ) : (
+                  <Shield size={18} className="text-muted-foreground" />
+                )}
+                Recovery Mode
+              </CardTitle>
+              {isActive && (
+                <Badge className="bg-orange-500/15 text-orange-500 border-orange-500/30">
+                  ACTIVE — {formatTime(countdown!)}
+                </Badge>
+              )}
+            </div>
+            {isActive ? (
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={handleDisable}
+                disabled={disableMutation.isPending}
+              >
+                <ShieldOff size={14} /> Disable
+              </Button>
+            ) : (
+              <Button size="sm" variant="outline" onClick={() => setConfirmOpen(true)}>
+                <Shield size={14} /> Enable
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {isActive ? (
+            <p className="text-sm text-orange-500">
+              Agents with valid tokens can auto-register without manual setup. This window will
+              close automatically when the timer expires.
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Enable recovery mode to allow deployed agents to re-register automatically after a
+              database reset. Agents must have a valid token configured.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Enable Recovery Mode</DialogTitle>
+            <DialogDescription>
+              During recovery mode, any machine that connects with a valid-format agent token will
+              be automatically registered. Only enable this after a database loss to recover
+              existing agents.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3 py-2">
+            <span className="text-sm font-medium">Duration</span>
+            <div className="flex gap-2">
+              {TTL_OPTIONS.map((opt) => (
+                <Button
+                  key={opt.value}
+                  size="sm"
+                  variant={selectedTtl === opt.value ? 'default' : 'outline'}
+                  onClick={() => setSelectedTtl(opt.value)}
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-orange-600 hover:bg-orange-700"
+              onClick={handleEnable}
+              disabled={enableMutation.isPending}
+            >
+              {enableMutation.isPending ? 'Enabling...' : 'Enable Recovery Mode'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import { NotificationsTab } from '@/components/notifications/NotificationsTab';
 import { RegistriesTab } from '@/components/registries/RegistriesTab';
 import { AboutTab } from '@/components/settings/AboutTab';
 import { ApiTokensTab } from '@/components/settings/ApiTokensTab';
+import { RecoveryModeCard } from '@/components/settings/RecoveryModeCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -163,6 +164,8 @@ function GeneralTab() {
           </div>
         </CardContent>
       </Card>
+
+      <RecoveryModeCard />
 
       <Card>
         <CardHeader>

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -125,7 +125,33 @@ Configure global update schedule, startup behavior, admin password, and agent re
 - **Global Schedule** — cron expression picker with presets (hourly, daily, weekly)
 - **Check on startup** — catch-up check if the last scheduled check was more than 24 hours ago
 - **Admin Password** — change the dashboard login password
+- **Recovery Mode** — time-limited window for automatic agent re-registration after database loss (see below)
 - **Register New Agent** — generate a token and get a ready-to-use docker run snippet
+
+### Recovery Mode
+
+If the controller's database is lost (e.g. the PostgreSQL volume is accidentally deleted), all agent registrations are gone and deployed agents can no longer authenticate. Recovery mode lets you restore connectivity without manually re-registering every agent.
+
+**How it works:**
+
+1. Go to **Settings → General → Recovery Mode**
+2. Click **Enable** and choose a duration (5, 15, 30, or 60 minutes)
+3. Confirm in the dialog — recovery mode activates with a visible countdown
+4. Already-deployed agents will automatically reconnect and re-register using their existing tokens
+5. Recovery mode expires automatically when the timer runs out, or you can disable it manually
+
+**Security:**
+
+- **Off by default** — normal operation uses strict bcrypt token authentication
+- **Time-bounded** — auto-expires after the chosen duration
+- **Token required** — agents must present a valid 64-character hex token (not arbitrary strings)
+- **Rate limited** — maximum 20 recovery registrations per window
+- **Audit logged** — every auto-registration is recorded with IP address, agent name, and hostname
+- **Flagged for review** — recovery-registered agents display an orange "Recovery" badge in the Agents page so you can verify they are legitimate
+
+:::caution
+Only enable recovery mode immediately after a database loss. During the recovery window, any machine on your network with a valid-format token can register as an agent. Keep the window as short as possible and review the Audit Log afterward.
+:::
 
 ### Notifications
 


### PR DESCRIPTION
## Summary

When the controller's PostgreSQL database is lost (e.g. the postgres container is accidentally recreated by "Update All"), all agent registrations are gone. Deployed agents keep trying to connect but get rejected because their token hashes no longer exist. Previously, the admin had to manually re-register every agent — generating new tokens, updating configs, restarting services across all hosts.

This PR adds **Recovery Mode** — a time-limited window where the admin can allow deployed agents to automatically re-register using their existing tokens.

### Changes

- **Controller**: `POST/GET/DELETE /api/recovery-mode` endpoints with admin auth, TTL validation (1-60 min)
- **WebSocket hub**: When normal auth fails + recovery mode active + valid 64-char hex token → auto-register agent with bcrypt-hashed token, audit log with IP
- **DB**: Migration 020 adds `recovery_registered` column to agents table; recovery state stored via existing config key-value table
- **Security**: Token format validation, 20 registrations/window rate limit, audit logging, time-bounded auto-expiry
- **UI**: Recovery Mode card in Settings → General with enable/disable, TTL selector (5/15/30/60 min), live countdown timer, confirmation dialog
- **UI**: Orange "Recovery" badge on auto-registered agents in AgentCard
- **Docs**: Recovery Mode section added to UI guide with security notes
- **Tests**: 14 API tests + 4 WebSocket integration tests covering enable/disable lifecycle, TTL validation, auth, auto-registration, token format rejection, agent deduplication

### Security considerations

| Aspect | Implementation |
|--------|---------------|
| Default state | OFF — strict bcrypt token auth in normal operation |
| Activation | Explicit admin action via authenticated API |
| Duration | Time-bounded, auto-expires after chosen TTL |
| Token validation | Only 64-char hex tokens accepted |
| Rate limiting | Max 20 recovery registrations per window |
| Audit trail | Every auto-registration logged with IP, agent name, hostname |
| Visibility | Recovery-registered agents flagged with orange badge for admin review |

**Residual risk**: During the recovery window, any machine on the local network with a valid-format token could register as an agent. Mitigated by short window, audit trail, and visual flag.

## Test plan

- [ ] Deploy controller with fresh DB — verify agents cannot connect
- [ ] Enable recovery mode (15 min) via Settings → General
- [ ] Verify agents auto-reconnect and appear with "Recovery" badge
- [ ] Check Audit Log for `agent.recovery_register` entries
- [ ] Wait for TTL expiry — verify recovery mode auto-disables
- [ ] Try connecting unknown agent after expiry — should be rejected
- [ ] Run `npm test` — all 18 new tests pass

Closes #8