### PR TITLE
feat: improve alert suppression for monitor-only refinements

### DIFF
--- a/agent/notify.go
+++ b/agent/notify.go
@@ -15,11 +15,13 @@ import (
 
 // Notifier fans out notifications to configured channels with per-container cooldown.
 type Notifier struct {
-	senders     []Sender
-	cooldown    map[string]time.Time
-	cooldownMu  sync.Mutex
-	cooldownTTL time.Duration
-	template    string // user-provided Go text/template
+	senders          []Sender
+	cooldown         map[string]time.Time
+	cooldownMu       sync.Mutex
+	cooldownTTL      time.Duration
+	resultCooldowns  map[string]time.Time // failure-notification cooldown per container
+	resultCooldownMu sync.Mutex
+	template         string // user-provided Go text/template
 }
 
 // renderNotificationTemplate renders a Go text/template with the given variables.
@@ -97,10 +99,11 @@ func NewNotifier(cfg *AgentConfig) *Notifier {
 	}
 
 	return &Notifier{
-		senders:     senders,
-		cooldown:    make(map[string]time.Time),
-		cooldownTTL: 5 * time.Minute,
-		template:    cfg.NotificationTemplate,
+		senders:         senders,
+		cooldown:        make(map[string]time.Time),
+		cooldownTTL:     5 * time.Minute,
+		resultCooldowns: make(map[string]time.Time),
+		template:        cfg.NotificationTemplate,
 	}
 }
 
@@ -206,6 +209,19 @@ func (n *Notifier) NotifyResult(result *UpdateResult) {
 		} else {
 			body = ""
 		}
+	}
+	// Suppress repeated failure notifications for the same container within 1 minute.
+	// Success notifications are never suppressed.
+	if !result.Success {
+		n.resultCooldownMu.Lock()
+		lastFail, exists := n.resultCooldowns[result.ContainerName]
+		if exists && time.Since(lastFail) < time.Minute {
+			n.resultCooldownMu.Unlock()
+			log.Printf("[notify] suppressing repeat failure notification for %s (cooldown)", result.ContainerName)
+			return
+		}
+		n.resultCooldowns[result.ContainerName] = time.Now()
+		n.resultCooldownMu.Unlock()
 	}
 	n.broadcast(title, body)
 }

--- a/controller/src/notifications/__tests__/session-batcher.test.ts
+++ b/controller/src/notifications/__tests__/session-batcher.test.ts
@@ -139,7 +139,7 @@ describe('session-batcher', () => {
     });
   });
 
-  it('dispatchCheckResults deduplicates same container within 1 hour', () => {
+  it('dispatchCheckResults deduplicates same container within 24 hours', () => {
     const u = uid();
 
     dispatchCheckResults(
@@ -164,6 +164,31 @@ describe('session-batcher', () => {
     vi.advanceTimersByTime(5_000);
     // The container was deduplicated, so the batch had 0 new containers.
     // flushCheckBatch filters out agents with no containers — no dispatch.
+    expect(notifier.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatchCheckResults deduplicates same container even when image changes (rolling :latest)', () => {
+    const u = uid();
+
+    dispatchCheckResults(
+      `agent-1-${u}`,
+      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+      `agent-1-${u}`,
+    );
+
+    vi.advanceTimersByTime(5_000);
+    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+
+    vi.mocked(notifier.dispatch).mockClear();
+
+    // Same container, different image digest / tag — should still be deduped by name
+    dispatchCheckResults(
+      `agent-1-${u}`,
+      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+      `agent-1-${u}`,
+    );
+
+    vi.advanceTimersByTime(5_000);
     expect(notifier.dispatch).not.toHaveBeenCalled();
   });
 

--- a/controller/src/notifications/session-batcher.ts
+++ b/controller/src/notifications/session-batcher.ts
@@ -130,9 +130,10 @@ export function addUpdateResult(agentId: string, result: UpdateResultItem): void
 }
 
 // Deduplicate: track which container updates we already notified about
-// Key: "agentId:containerName:image" → timestamp. Entries expire after 1 hour.
+// Key: "agentId:containerName" → timestamp. Entries expire after 24 hours.
+// Image/digest is intentionally excluded so rolling :latest tags don't bypass dedup.
 const notifiedUpdates = new Map<string, number>();
-const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_DEDUP_ENTRIES = 10000;
 
 function pruneNotified(): void {
@@ -259,7 +260,7 @@ export function dispatchCheckResults(
   // Deduplicate: only include containers we haven't notified about yet
   pruneNotified();
   const newContainers = containers.filter((c) => {
-    const key = `${agentId ?? agentName}:${c.name}:${c.image}`;
+    const key = `${agentId ?? agentName}:${c.name}`;
     if (notifiedUpdates.has(key)) return false;
     notifiedUpdates.set(key, Date.now());
     return true;

--- a/controller/src/scheduler/__tests__/engine.test.ts
+++ b/controller/src/scheduler/__tests__/engine.test.ts
@@ -180,6 +180,10 @@ describe('Scheduler', () => {
   it('L2: does NOT run catch-up when last run is recent', async () => {
     await setConfig('check_on_startup', 'true');
     await setConfig('scheduler_last_run', String(Date.now() - 3600000)); // 1h ago
+    // Use a non-firing schedule so the cron does not produce a CHECK message
+    // during the 1.5s observation window (the default * * * * * fires at :00
+    // of each minute and would cause a false positive if the test starts at :59).
+    await setConfig('global_schedule', '0 4 * * *');
 
     mockHub.sentMessages.length = 0;
 


### PR DESCRIPTION
session-batcher: change dedup key from agentId:container:image to agentId:container, extend TTL from 1h to 24h. Rolling :latest tags previously bypassed dedup because each digest produced a unique key — now the same container is silenced for 24h regardless of image changes.

agent/notify.go: add 1-minute failure cooldown to NotifyResult. Repeated failure notifications for the same container are suppressed within the window to avoid alert storms during crash loops. Success notifications are never suppressed.

closed #18 