### PR TITLE
Develop into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,10 @@ Thumbs.db
 # Test
 coverage/
 
-# Plan
+# Plan / Claude working docs
 PLAN.md
+WW-roadmap-for-claude.md
+reference-feature-audit.md
 
 # Local settings & config
 settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## Unreleased
-
-### Features
-- feat: persist image diff in update_log and show in Update History UI — breaking-change badges and full diff view now available in history expanded rows
-
----
-
 ## v0.2.1
 
 Released: 2026-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Features
+- feat: persist image diff in update_log and show in Update History UI — breaking-change badges and full diff view now available in history expanded rows
+
+---
+
 ## v0.2.1
 
 Released: 2026-04-07

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **Tag pattern matching** — filter registry tags by regex via `com.watchwarden.tag_pattern` label
 - **Pinned version detection** — blocks accidental updates for containers with explicit version tags (e.g. `postgres:16.2-alpine`), while correctly treating floating tags (`alpine`, `lts`, `stable`) as updatable
 - **Config-only change detection** — detects image updates even when only entrypoint/env/labels changed (same manifest digest, different image ID)
-- **Image diff preview** — shows env, port, entrypoint, and volume changes before updating
+- **Image diff preview** — shows env, port, entrypoint, and volume changes before updating; diff is also persisted in update history so you can review configuration changes post-update
 - **Health-based auto-rollback** — rolls back automatically if a container becomes unhealthy after update, respects healthcheck `start_period` for slow-starting containers
 - **Crash-loop detection** — detects and rolls back containers stuck in restart loops (requires 3+ restarts in 60s to avoid false positives)
 - **AutoRemove container support** — safely updates `--rm` containers by handling Docker API 409/404 during removal

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **Blue-green updates** — start new container first, verify health, then stop old (zero-downtime). Automatically falls back to stop-first if port conflicts are detected (e.g. containers with direct port mappings)
 - **Rollback** — roll back to any previous version or pick a specific tag from the registry
 - **Update groups** — label-based dependency ordering (`com.watchwarden.group`, `com.watchwarden.depends_on`)
-- **Per-container policies** — label-driven control: `com.watchwarden.policy=auto|notify|manual` per container
+- **Per-container policies** — label-driven control: `com.watchwarden.policy=auto|notify|manual` per container; editable from the UI without labels
+- **Semver update levels** — restrict how far images can be upgraded (`patch`, `minor`, `major`) per container or globally via Settings; enforced before auto-update
 - **Tag pattern matching** — filter registry tags by regex via `com.watchwarden.tag_pattern` label
 - **Pinned version detection** — blocks accidental updates for containers with explicit version tags (e.g. `postgres:16.2-alpine`), while correctly treating floating tags (`alpine`, `lts`, `stable`) as updatable
 - **Config-only change detection** — detects image updates even when only entrypoint/env/labels changed (same manifest digest, different image ID)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **TypeScript SDK** — `@watchwarden/sdk` for programmatic access
 
 ### Observability
-- **Prometheus metrics** — `/metrics` endpoint on the controller exposes container counts, update status, and agent health in standard Prometheus format
+- **Prometheus metrics** — `/metrics` endpoint with per-container labeled gauges (`container_info`, `container_has_update`, `container_last_updated_ms`) and aggregate counters for agents, update counts by status
 
 ### Notifications
 - **Telegram, Slack, Webhook, ntfy** — configurable channels with batched, deduplicated messages

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 
 ### Updates & Rollback
 - **Automatic updates** — schedule checks globally or per-agent, with optional auto-update
+- **Minimum update age** — hold back auto-updates until an available update has been visible for N hours (configurable per agent), avoiding races with newly-broken tags
 - **Blue-green updates** — start new container first, verify health, then stop old (zero-downtime). Automatically falls back to stop-first if port conflicts are detected (e.g. containers with direct port mappings)
 - **Rollback** — roll back to any previous version or pick a specific tag from the registry
 - **Update groups** — label-based dependency ordering (`com.watchwarden.group`, `com.watchwarden.depends_on`)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **Tag pattern matching** — filter registry tags by regex via `com.watchwarden.tag_pattern` label
 - **Pinned version detection** — blocks accidental updates for containers with explicit version tags (e.g. `postgres:16.2-alpine`), while correctly treating floating tags (`alpine`, `lts`, `stable`) as updatable
 - **Config-only change detection** — detects image updates even when only entrypoint/env/labels changed (same manifest digest, different image ID)
-- **Image diff preview** — shows env, port, entrypoint, and volume changes before updating; diff is also persisted in update history so you can review configuration changes post-update
+- **Image diff preview** — shows env, port, entrypoint, and volume changes before updating
 - **Health-based auto-rollback** — rolls back automatically if a container becomes unhealthy after update, respects healthcheck `start_period` for slow-starting containers
 - **Crash-loop detection** — detects and rolls back containers stuck in restart loops (requires 3+ restarts in 60s to avoid false positives)
 - **AutoRemove container support** — safely updates `--rm` containers by handling Docker API 409/404 during removal

--- a/agent/interfaces.go
+++ b/agent/interfaces.go
@@ -75,6 +75,8 @@ type UpdateResult struct {
 	Success       bool   `json:"success"`
 	OldDigest     string `json:"oldDigest,omitempty"`
 	NewDigest     string `json:"newDigest,omitempty"`
+	OldImage      string `json:"oldImage,omitempty"`
+	NewImage      string `json:"newImage,omitempty"`
 	Error         string `json:"error,omitempty"`
 	DurationMs    int64  `json:"durationMs,omitempty"`
 	IsRollback    bool   `json:"isRollback,omitempty"`

--- a/agent/notify.go
+++ b/agent/notify.go
@@ -174,6 +174,28 @@ func (n *Notifier) NotifyAvailable(agentName string, updates []CheckResult) {
 	n.broadcast(title, body)
 }
 
+// formatImageLabel returns a human-readable image label combining tag and short digest.
+// Format: "image:tag (sha256:short...)" or just the tag/digest if only one is available.
+func formatImageLabel(image, digest string) string {
+	if image == "" && digest == "" {
+		return ""
+	}
+	if image == "" {
+		if len(digest) > 19 {
+			return digest[:19] + "..."
+		}
+		return digest
+	}
+	if digest != "" {
+		short := digest
+		if len(short) > 19 {
+			short = short[:19] + "..."
+		}
+		return fmt.Sprintf("%s (%s)", image, short)
+	}
+	return image
+}
+
 // NotifyResult sends a notification about a single update result.
 func (n *Notifier) NotifyResult(result *UpdateResult) {
 	if !n.IsConfigured() || result == nil {
@@ -182,7 +204,12 @@ func (n *Notifier) NotifyResult(result *UpdateResult) {
 	var title, body string
 	if result.Success {
 		title = fmt.Sprintf("Updated — %s", result.ContainerName)
-		body = fmt.Sprintf("Duration: %dms", result.DurationMs)
+		newLabel := formatImageLabel(result.NewImage, result.NewDigest)
+		if newLabel != "" {
+			body = fmt.Sprintf("%s (%dms)", newLabel, result.DurationMs)
+		} else {
+			body = fmt.Sprintf("Duration: %dms", result.DurationMs)
+		}
 	} else {
 		title = fmt.Sprintf("Update Failed — %s", result.ContainerName)
 		body = result.Error
@@ -195,6 +222,8 @@ func (n *Notifier) NotifyResult(result *UpdateResult) {
 			"Success":       fmt.Sprintf("%v", result.Success),
 			"OldDigest":     result.OldDigest,
 			"NewDigest":     result.NewDigest,
+			"OldImage":      result.OldImage,
+			"NewImage":      result.NewImage,
 			"Duration":      fmt.Sprintf("%dms", result.DurationMs),
 			"Error":         result.Error,
 		}
@@ -222,7 +251,12 @@ func (n *Notifier) NotifyResults(agentName string, results []*UpdateResult) {
 	for _, r := range results {
 		if r.Success {
 			successes++
-			lines = append(lines, fmt.Sprintf("✓ %s (%dms)", r.ContainerName, r.DurationMs))
+			newLabel := formatImageLabel(r.NewImage, r.NewDigest)
+			if newLabel != "" {
+				lines = append(lines, fmt.Sprintf("✓ %s → %s (%dms)", r.ContainerName, newLabel, r.DurationMs))
+			} else {
+				lines = append(lines, fmt.Sprintf("✓ %s (%dms)", r.ContainerName, r.DurationMs))
+			}
 		} else {
 			failures++
 			lines = append(lines, fmt.Sprintf("✗ %s: %s", r.ContainerName, r.Error))

--- a/agent/notify.go
+++ b/agent/notify.go
@@ -15,11 +15,13 @@ import (
 
 // Notifier fans out notifications to configured channels with per-container cooldown.
 type Notifier struct {
-	senders     []Sender
-	cooldown    map[string]time.Time
-	cooldownMu  sync.Mutex
-	cooldownTTL time.Duration
-	template    string // user-provided Go text/template
+	senders          []Sender
+	cooldown         map[string]time.Time
+	cooldownMu       sync.Mutex
+	cooldownTTL      time.Duration
+	resultCooldowns  map[string]time.Time // failure-notification cooldown per container
+	resultCooldownMu sync.Mutex
+	template         string // user-provided Go text/template
 }
 
 // renderNotificationTemplate renders a Go text/template with the given variables.
@@ -97,10 +99,11 @@ func NewNotifier(cfg *AgentConfig) *Notifier {
 	}
 
 	return &Notifier{
-		senders:     senders,
-		cooldown:    make(map[string]time.Time),
-		cooldownTTL: 5 * time.Minute,
-		template:    cfg.NotificationTemplate,
+		senders:         senders,
+		cooldown:        make(map[string]time.Time),
+		cooldownTTL:     5 * time.Minute,
+		resultCooldowns: make(map[string]time.Time),
+		template:        cfg.NotificationTemplate,
 	}
 }
 
@@ -206,6 +209,19 @@ func (n *Notifier) NotifyResult(result *UpdateResult) {
 		} else {
 			body = ""
 		}
+	}
+	// Suppress repeated failure notifications for the same container within 1 minute.
+	// Success notifications are never suppressed.
+	if !result.Success {
+		n.resultCooldownMu.Lock()
+		lastFail, exists := n.resultCooldowns[result.ContainerName]
+		if exists && time.Since(lastFail) < time.Minute {
+			n.resultCooldownMu.Unlock()
+			log.Printf("[notify] suppressing repeat failure notification for %s (cooldown)", result.ContainerName)
+			return
+		}
+		n.resultCooldowns[result.ContainerName] = time.Now()
+		n.resultCooldownMu.Unlock()
 	}
 	n.broadcast(title, body)
 }

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -486,6 +486,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 				ContainerName: snapshot.Name,
 				Success:       false,
 				OldDigest:     snapshot.ImageDigest,
+				OldImage:      snapshot.ImageRef,
 				Error:         err.Error(),
 				DurationMs:    time.Since(start).Milliseconds(),
 			}, err
@@ -510,6 +511,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 			ContainerName: snapshot.Name,
 			Success:       false,
 			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
 			Error:         fmt.Sprintf("pull failed: %v", err),
 			DurationMs:    time.Since(start).Milliseconds(),
 		}, err
@@ -551,6 +553,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 			ContainerName: snapshot.Name,
 			Success:       false,
 			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
 			Error:         fmt.Sprintf("stop failed: %v", err),
 			DurationMs:    time.Since(start).Milliseconds(),
 		}, err
@@ -566,6 +569,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 				ContainerName: snapshot.Name,
 				Success:       false,
 				OldDigest:     snapshot.ImageDigest,
+				OldImage:      snapshot.ImageRef,
 				Error:         fmt.Sprintf("remove failed: %v", err),
 				DurationMs:    time.Since(start).Milliseconds(),
 			}, err
@@ -588,6 +592,7 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 			ContainerName: snapshot.Name,
 			Success:       false,
 			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
 			Error:         errMsg,
 			DurationMs:    time.Since(start).Milliseconds(),
 		}, err
@@ -599,6 +604,8 @@ func (u *Updater) UpdateContainer(ctx context.Context, containerID string) (*Upd
 		Success:       true,
 		OldDigest:     snapshot.ImageDigest,
 		NewDigest:     newDigest,
+		OldImage:      snapshot.ImageRef,
+		NewImage:      imageRef,
 		DurationMs:    time.Since(start).Milliseconds(),
 	}, nil
 }
@@ -643,6 +650,8 @@ func (u *Updater) RollbackContainer(ctx context.Context, containerID string) (*U
 		ContainerName: snapshot.Name,
 		Success:       true,
 		OldDigest:     snapshot.ImageDigest,
+		OldImage:      snapshot.ImageRef,
+		NewImage:      snapshot.ImageRef,
 		DurationMs:    time.Since(start).Milliseconds(),
 		IsRollback:    true,
 	}, nil
@@ -769,6 +778,8 @@ func (u *Updater) RollbackToImage(ctx context.Context, containerID string, targe
 		Success:       true,
 		OldDigest:     snapshot.ImageDigest,
 		NewDigest:     newDigest,
+		OldImage:      snapshot.ImageRef,
+		NewImage:      targetImage,
 		DurationMs:    time.Since(start).Milliseconds(),
 		IsRollback:    true,
 	}, nil
@@ -916,6 +927,8 @@ func (u *Updater) BlueGreenUpdate(ctx context.Context, containerID string) (*Upd
 		Success:       true,
 		OldDigest:     snapshot.ImageDigest,
 		NewDigest:     newDigest,
+		OldImage:      snapshot.ImageRef,
+		NewImage:      bgImageRef,
 		DurationMs:    time.Since(start).Milliseconds(),
 	}, nil
 }

--- a/controller/src/api/routes/agents.ts
+++ b/controller/src/api/routes/agents.ts
@@ -12,6 +12,7 @@ import {
   insertAgent,
   listAgents,
   updateAgentConfig,
+  updateContainerPolicy,
 } from '../../db/queries.js';
 import { expectCheckResults } from '../../notifications/session-batcher.js';
 import type { AgentHub } from '../../ws/hub.js';
@@ -440,6 +441,33 @@ const agentsRoutes: FastifyPluginAsync = async (fastify) => {
         error: err instanceof Error ? err.message : 'Agent request timed out',
       });
     }
+  });
+
+  fastify.patch<{
+    Params: { agentId: string; containerId: string };
+    Body: { policy: string | null; update_level: string | null };
+  }>('/api/agents/:agentId/containers/:containerId', async (request, reply) => {
+    const { agentId, containerId } = request.params;
+    const { policy, update_level } = request.body;
+
+    const agent = await getAgent(agentId);
+    if (!agent) return reply.code(404).send({ error: 'Agent not found' });
+
+    const validPolicies = new Set([null, 'auto', 'notify', 'manual']);
+    if (!validPolicies.has(policy)) {
+      return reply
+        .code(400)
+        .send({ error: 'Invalid policy. Must be one of: auto, notify, manual' });
+    }
+    const validLevels = new Set([null, '', 'all', 'major', 'minor', 'patch']);
+    if (!validLevels.has(update_level)) {
+      return reply.code(400).send({
+        error: 'Invalid update_level. Must be one of: all, major, minor, patch',
+      });
+    }
+
+    await updateContainerPolicy(containerId, { policy, update_level });
+    return reply.code(200).send({ message: 'Container policy updated' });
   });
 
   fastify.post<{

--- a/controller/src/api/routes/config.ts
+++ b/controller/src/api/routes/config.ts
@@ -12,7 +12,13 @@ import {
 import { requireAuth } from '../middleware/auth.js';
 
 const CRON_KEYS = new Set(['global_schedule']);
-const ALLOWED_CONFIG_KEYS = new Set(['global_schedule', 'auto_update_global', 'check_on_startup']);
+const ALLOWED_CONFIG_KEYS = new Set([
+  'global_schedule',
+  'auto_update_global',
+  'check_on_startup',
+  'global_update_level',
+]);
+const VALID_UPDATE_LEVELS = new Set(['', 'all', 'major', 'minor', 'patch']);
 
 const SENSITIVE_CONFIG_KEYS = new Set(['jwt_secret', 'admin_password_hash']);
 
@@ -39,6 +45,12 @@ const configRoutes: FastifyPluginAsync = async (fastify) => {
 
     if (CRON_KEYS.has(key) && !cron.validate(value)) {
       return reply.code(400).send({ error: 'Invalid cron expression' });
+    }
+
+    if (key === 'global_update_level' && !VALID_UPDATE_LEVELS.has(value)) {
+      return reply
+        .code(400)
+        .send({ error: `Invalid update level. Must be one of: all, major, minor, patch` });
     }
 
     await setConfig(key, value);

--- a/controller/src/api/routes/config.ts
+++ b/controller/src/api/routes/config.ts
@@ -83,12 +83,22 @@ const configRoutes: FastifyPluginAsync = async (fastify) => {
       autoRollbackEnabled?: boolean;
       maxUnhealthySeconds?: number;
       strategy?: string;
+      minAgeHours?: number;
     };
   }>('/api/update-policies', async (request, reply) => {
-    const { scope, stabilityWindowSeconds, autoRollbackEnabled, maxUnhealthySeconds, strategy } =
-      request.body;
+    const {
+      scope,
+      stabilityWindowSeconds,
+      autoRollbackEnabled,
+      maxUnhealthySeconds,
+      strategy,
+      minAgeHours,
+    } = request.body;
     if (!scope || !/^(global|agent:[a-f0-9-]+)$/.test(scope)) {
       return reply.code(400).send({ error: 'Invalid scope format' });
+    }
+    if (minAgeHours !== undefined && (!Number.isInteger(minAgeHours) || minAgeHours < 0)) {
+      return reply.code(400).send({ error: 'minAgeHours must be a non-negative integer' });
     }
     const existing = await getEffectivePolicy(
       scope === 'global' ? undefined : scope.replace(/^agent:/, ''),
@@ -101,6 +111,7 @@ const configRoutes: FastifyPluginAsync = async (fastify) => {
       auto_rollback_enabled: autoRollbackEnabled ?? existing.auto_rollback_enabled,
       max_unhealthy_seconds: maxUnhealthySeconds ?? existing.max_unhealthy_seconds,
       strategy: strategy ?? existing.strategy ?? 'stop-first',
+      min_age_hours: minAgeHours ?? existing.min_age_hours ?? 0,
     });
     return { message: 'Policy updated' };
   });

--- a/controller/src/api/routes/metrics.ts
+++ b/controller/src/api/routes/metrics.ts
@@ -1,30 +1,43 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { sql } from '../../db/client.js';
-import { getContainersByAgent, listAgents } from '../../db/queries.js';
+import { listAgents, listAllContainersWithAgent } from '../../db/queries.js';
+
+/** Escape a label value per the Prometheus text exposition format. */
+function escapeLabel(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
 
 const metricsRoutes: FastifyPluginAsync = async (fastify) => {
   // No auth required — standard for Prometheus scraping
   fastify.get('/metrics', async (_request, reply) => {
-    const agents = await listAgents();
+    const [agents, allContainers] = await Promise.all([listAgents(), listAllContainersWithAgent()]);
+
     const onlineAgents = agents.filter((a) => a.status === 'online').length;
-
-    let totalContainers = 0;
-    let updatesAvailable = 0;
-    let excludedContainers = 0;
-
-    for (const agent of agents) {
-      const containers = await getContainersByAgent(agent.id);
-      totalContainers += containers.length;
-      updatesAvailable += containers.filter((c) => c.has_update === 1).length;
-      excludedContainers += containers.filter((c) => c.excluded === 1).length;
-    }
+    const totalContainers = allContainers.length;
+    const updatesAvailable = allContainers.filter((c) => c.has_update === 1).length;
+    const excludedContainers = allContainers.filter((c) => c.excluded === 1).length;
 
     // Query update counts from DB
-    const successCount =
-      await sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'success'`;
-    const failedCount = await sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'failed'`;
-    const rolledBackCount =
-      await sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'rolled_back'`;
+    const [successCount, failedCount, rolledBackCount] = await Promise.all([
+      sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'success'`,
+      sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'failed'`,
+      sql`SELECT COUNT(*) as count FROM update_log WHERE status = 'rolled_back'`,
+    ]);
+
+    const containerInfoLines = allContainers.map(
+      (c) =>
+        `watchwarden_container_info{agent="${escapeLabel(c.agent_name)}",container="${escapeLabel(c.name)}",image="${escapeLabel(c.image)}"} 1`,
+    );
+
+    const containerUpdateLines = allContainers.map(
+      (c) =>
+        `watchwarden_container_has_update{agent="${escapeLabel(c.agent_name)}",container="${escapeLabel(c.name)}"} ${c.has_update === 1 ? 1 : 0}`,
+    );
+
+    const containerLastUpdatedLines = allContainers.map(
+      (c) =>
+        `watchwarden_container_last_updated_ms{agent="${escapeLabel(c.agent_name)}",container="${escapeLabel(c.name)}"} ${c.last_updated ?? 0}`,
+    );
 
     const lines = [
       '# HELP watchwarden_agents_total Total number of registered agents',
@@ -52,6 +65,18 @@ const metricsRoutes: FastifyPluginAsync = async (fastify) => {
       `watchwarden_updates_total{status="success"} ${Number(successCount[0]?.count ?? 0)}`,
       `watchwarden_updates_total{status="failed"} ${Number(failedCount[0]?.count ?? 0)}`,
       `watchwarden_updates_total{status="rolled_back"} ${Number(rolledBackCount[0]?.count ?? 0)}`,
+      '',
+      '# HELP watchwarden_container_info Static info per container (agent, name, image)',
+      '# TYPE watchwarden_container_info gauge',
+      ...containerInfoLines,
+      '',
+      '# HELP watchwarden_container_has_update Whether the container has a pending update (0 or 1)',
+      '# TYPE watchwarden_container_has_update gauge',
+      ...containerUpdateLines,
+      '',
+      '# HELP watchwarden_container_last_updated_ms Unix timestamp (ms) of last successful update, 0 if never',
+      '# TYPE watchwarden_container_last_updated_ms gauge',
+      ...containerLastUpdatedLines,
       '',
     ];
 

--- a/controller/src/db/migrations/021-aging.sql
+++ b/controller/src/db/migrations/021-aging.sql
@@ -1,0 +1,2 @@
+ALTER TABLE containers ADD COLUMN IF NOT EXISTS update_first_seen BIGINT;
+ALTER TABLE update_policies ADD COLUMN IF NOT EXISTS min_age_hours INTEGER DEFAULT 0;

--- a/controller/src/db/migrations/021-diff-in-history.sql
+++ b/controller/src/db/migrations/021-diff-in-history.sql
@@ -1,0 +1,1 @@
+ALTER TABLE update_log ADD COLUMN IF NOT EXISTS diff TEXT;

--- a/controller/src/db/migrations/021-update-log-images.sql
+++ b/controller/src/db/migrations/021-update-log-images.sql
@@ -1,0 +1,2 @@
+ALTER TABLE update_log ADD COLUMN IF NOT EXISTS old_image TEXT;
+ALTER TABLE update_log ADD COLUMN IF NOT EXISTS new_image TEXT;

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -181,6 +181,16 @@ export async function updateContainerDigests(
   `;
 }
 
+export async function setUpdateFirstSeen(
+  containerId: string,
+  timestamp: number | null,
+): Promise<void> {
+  await sql`
+    UPDATE containers SET update_first_seen = ${timestamp}
+    WHERE id = ${containerId} OR docker_id = ${containerId}
+  `;
+}
+
 // --- Update Log ---
 
 export async function insertUpdateLog(entry: NewUpdateLog): Promise<number> {
@@ -499,6 +509,7 @@ export interface UpdatePolicy {
   auto_rollback_enabled: boolean;
   max_unhealthy_seconds: number;
   strategy: string;
+  min_age_hours: number;
   created_at: number;
 }
 
@@ -512,6 +523,7 @@ export async function getUpdatePolicy(scope: string): Promise<UpdatePolicy | und
     auto_rollback_enabled: !!row.auto_rollback_enabled,
     max_unhealthy_seconds: Number(row.max_unhealthy_seconds),
     strategy: (row.strategy as string) ?? 'stop-first',
+    min_age_hours: Number(row.min_age_hours ?? 0),
     created_at: Number(row.created_at),
   };
 }
@@ -530,6 +542,7 @@ export async function getEffectivePolicy(agentId?: string): Promise<UpdatePolicy
       auto_rollback_enabled: true,
       max_unhealthy_seconds: 30,
       strategy: 'stop-first',
+      min_age_hours: 0,
       created_at: 0,
     }
   );
@@ -537,13 +550,14 @@ export async function getEffectivePolicy(agentId?: string): Promise<UpdatePolicy
 
 export async function upsertUpdatePolicy(policy: Omit<UpdatePolicy, 'created_at'>): Promise<void> {
   await sql`
-    INSERT INTO update_policies (id, scope, stability_window_seconds, auto_rollback_enabled, max_unhealthy_seconds, strategy, created_at)
-    VALUES (${policy.id}, ${policy.scope}, ${policy.stability_window_seconds}, ${policy.auto_rollback_enabled}, ${policy.max_unhealthy_seconds}, ${policy.strategy}, ${Date.now()})
+    INSERT INTO update_policies (id, scope, stability_window_seconds, auto_rollback_enabled, max_unhealthy_seconds, strategy, min_age_hours, created_at)
+    VALUES (${policy.id}, ${policy.scope}, ${policy.stability_window_seconds}, ${policy.auto_rollback_enabled}, ${policy.max_unhealthy_seconds}, ${policy.strategy}, ${policy.min_age_hours}, ${Date.now()})
     ON CONFLICT (id) DO UPDATE SET
       stability_window_seconds = EXCLUDED.stability_window_seconds,
       auto_rollback_enabled = EXCLUDED.auto_rollback_enabled,
       max_unhealthy_seconds = EXCLUDED.max_unhealthy_seconds,
-      strategy = EXCLUDED.strategy
+      strategy = EXCLUDED.strategy,
+      min_age_hours = EXCLUDED.min_age_hours
   `;
 }
 
@@ -678,6 +692,7 @@ function mapContainer(row: Record<string, unknown>): Container {
     last_checked: row.last_checked ? Number(row.last_checked) : null,
     last_updated: row.last_updated ? Number(row.last_updated) : null,
     is_stateful: row.is_stateful ? 1 : 0,
+    update_first_seen: row.update_first_seen ? Number(row.update_first_seen) : null,
   };
 }
 

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -558,6 +558,16 @@ export async function updateContainerDiff(containerId: string, diff: string | nu
   `;
 }
 
+export async function updateContainerPolicy(
+  containerId: string,
+  data: { policy: string | null; update_level: string | null },
+): Promise<void> {
+  await sql`
+    UPDATE containers SET policy = ${data.policy}, update_level = ${data.update_level}
+    WHERE id = ${containerId} OR docker_id = ${containerId}
+  `;
+}
+
 // --- Scan Results ---
 
 export async function insertScanResult(

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -232,11 +232,12 @@ export async function getHistory(
   const offset = filters.offset ?? 0;
 
   // Build WHERE fragment using postgres.js tagged template fragments (no sql.unsafe)
-  const agentFilter = filters.agentId ? sql`AND agent_id = ${filters.agentId}` : sql``;
-  const statusFilter = filters.status ? sql`AND status = ${filters.status}` : sql``;
+  // Qualify all columns with table prefix to avoid ambiguity with the agents JOIN
+  const agentFilter = filters.agentId ? sql`AND ul.agent_id = ${filters.agentId}` : sql``;
+  const statusFilter = filters.status ? sql`AND ul.status = ${filters.status}` : sql``;
 
   const [totalRow] = await sql`
-		SELECT COUNT(*) as count FROM update_log WHERE TRUE ${agentFilter} ${statusFilter}
+		SELECT COUNT(*) as count FROM update_log ul WHERE TRUE ${agentFilter} ${statusFilter}
 	`;
   const total = Number(totalRow?.count ?? 0);
 

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -185,11 +185,11 @@ export async function updateContainerDigests(
 
 export async function insertUpdateLog(entry: NewUpdateLog): Promise<number> {
   const [row] = await sql`
-    INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, created_at)
+    INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, diff, created_at)
     VALUES (${entry.agent_id}, ${entry.container_id}, ${entry.container_name},
       ${entry.old_digest ?? null}, ${entry.new_digest ?? null},
       ${entry.old_image ?? null}, ${entry.new_image ?? null},
-      ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
+      ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${entry.diff ?? null}, ${Date.now()})
     RETURNING id
   `;
   return Number(row?.id ?? 0);
@@ -208,11 +208,11 @@ export async function insertUpdateLogAndDigests(
   await sql.begin(async (txBase) => {
     const tx = txBase as unknown as TxSql;
     const [row] = await tx`
-      INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, created_at)
+      INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, diff, created_at)
       VALUES (${entry.agent_id}, ${entry.container_id}, ${entry.container_name},
         ${entry.old_digest ?? null}, ${entry.new_digest ?? null},
         ${entry.old_image ?? null}, ${entry.new_image ?? null},
-        ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
+        ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${entry.diff ?? null}, ${Date.now()})
       RETURNING id
     `;
     logId = Number(row?.id ?? 0);
@@ -695,6 +695,7 @@ function mapUpdateLog(row: Record<string, unknown>): UpdateLog {
     status: row.status as 'success' | 'failed' | 'rolled_back',
     error: row.error as string | null,
     duration_ms: row.duration_ms ? Number(row.duration_ms) : null,
+    diff: (row.diff as string | null) ?? null,
     created_at: Number(row.created_at),
   };
 }

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -185,10 +185,11 @@ export async function updateContainerDigests(
 
 export async function insertUpdateLog(entry: NewUpdateLog): Promise<number> {
   const [row] = await sql`
-    INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, status, error, duration_ms, created_at)
+    INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, created_at)
     VALUES (${entry.agent_id}, ${entry.container_id}, ${entry.container_name},
-      ${entry.old_digest ?? null}, ${entry.new_digest ?? null}, ${entry.status},
-      ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
+      ${entry.old_digest ?? null}, ${entry.new_digest ?? null},
+      ${entry.old_image ?? null}, ${entry.new_image ?? null},
+      ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
     RETURNING id
   `;
   return Number(row?.id ?? 0);
@@ -207,10 +208,11 @@ export async function insertUpdateLogAndDigests(
   await sql.begin(async (txBase) => {
     const tx = txBase as unknown as TxSql;
     const [row] = await tx`
-      INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, status, error, duration_ms, created_at)
+      INSERT INTO update_log (agent_id, container_id, container_name, old_digest, new_digest, old_image, new_image, status, error, duration_ms, created_at)
       VALUES (${entry.agent_id}, ${entry.container_id}, ${entry.container_name},
-        ${entry.old_digest ?? null}, ${entry.new_digest ?? null}, ${entry.status},
-        ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
+        ${entry.old_digest ?? null}, ${entry.new_digest ?? null},
+        ${entry.old_image ?? null}, ${entry.new_image ?? null},
+        ${entry.status}, ${entry.error ?? null}, ${entry.duration_ms ?? null}, ${Date.now()})
       RETURNING id
     `;
     logId = Number(row?.id ?? 0);
@@ -239,8 +241,11 @@ export async function getHistory(
   const total = Number(totalRow?.count ?? 0);
 
   const data = await sql`
-		SELECT * FROM update_log WHERE TRUE ${agentFilter} ${statusFilter}
-		ORDER BY created_at DESC LIMIT ${limit} OFFSET ${offset}
+		SELECT ul.*, a.name as agent_name
+		FROM update_log ul
+		LEFT JOIN agents a ON ul.agent_id = a.id
+		WHERE TRUE ${agentFilter} ${statusFilter}
+		ORDER BY ul.created_at DESC LIMIT ${limit} OFFSET ${offset}
 	`;
 
   return { data: data.map(mapUpdateLog), total };
@@ -669,10 +674,13 @@ function mapUpdateLog(row: Record<string, unknown>): UpdateLog {
   return {
     id: Number(row.id),
     agent_id: row.agent_id as string,
+    agent_name: (row.agent_name as string | null) ?? null,
     container_id: row.container_id as string,
     container_name: row.container_name as string,
     old_digest: row.old_digest as string | null,
     new_digest: row.new_digest as string | null,
+    old_image: (row.old_image as string | null) ?? null,
+    new_image: (row.new_image as string | null) ?? null,
     status: row.status as 'success' | 'failed' | 'rolled_back',
     error: row.error as string | null,
     duration_ms: row.duration_ms ? Number(row.duration_ms) : null,

--- a/controller/src/lib/semver.ts
+++ b/controller/src/lib/semver.ts
@@ -1,0 +1,76 @@
+/**
+ * Semver-level update filtering — TypeScript port of SemverMatchesLevel from agent/registry.go.
+ *
+ * Levels:
+ *   "patch" — same major+minor, higher patch only
+ *   "minor" — same major, any minor/patch increase
+ *   "major" / "all" / "" — any version increase
+ */
+
+function extractVersionParts(tag: string): number[] {
+  // Strip v/V prefix and common suffixes like "-alpine", "-slim"
+  const stripped = tag.replace(/^[vV]/, '');
+  const parts: number[] = [];
+  for (const seg of stripped.split(/[.\-_]/)) {
+    const n = Number.parseInt(seg, 10);
+    if (!Number.isNaN(n)) {
+      parts.push(n);
+    } else if (parts.length > 0) {
+      break; // stop at first non-numeric segment after we have some numbers
+    }
+  }
+  return parts;
+}
+
+/**
+ * Returns true if `candidate` is a valid update for `current` under the given `level` constraint.
+ * When versions cannot be parsed, any change is allowed (safe fallback).
+ */
+export function semverMatchesLevel(current: string, candidate: string, level: string): boolean {
+  const cur = extractVersionParts(current);
+  const can = extractVersionParts(candidate);
+
+  if (cur.length === 0 || can.length === 0) {
+    return candidate !== current;
+  }
+
+  while (cur.length < 3) cur.push(0);
+  while (can.length < 3) can.push(0);
+
+  switch (level) {
+    case 'patch':
+      return can[0] === cur[0] && can[1] === cur[1] && (can[2] ?? 0) > (cur[2] ?? 0);
+    case 'minor':
+      if (can[0] !== cur[0]) return false;
+      if ((can[1] ?? 0) > (cur[1] ?? 0)) return true;
+      return (can[1] ?? 0) === (cur[1] ?? 0) && (can[2] ?? 0) > (cur[2] ?? 0);
+    case 'major':
+    case 'all':
+    default:
+      for (let i = 0; i < 3; i++) {
+        if ((can[i] ?? 0) > (cur[i] ?? 0)) return true;
+        if ((can[i] ?? 0) < (cur[i] ?? 0)) return false;
+      }
+      return false;
+  }
+}
+
+/**
+ * Extracts the tag portion from an image reference.
+ * "postgres:15.1"          -> "15.1"
+ * "ghcr.io/org/app:1.2.3"  -> "1.2.3"
+ * "postgres"               -> "latest"
+ * "sha256:abc..."          -> "" (digest — not a tag)
+ */
+export function extractTag(imageRef: string): string {
+  if (!imageRef) return '';
+  if (imageRef.startsWith('sha256:')) return '';
+  // Strip digest portion (image@sha256:...)
+  const withoutDigest = imageRef.split('@')[0] ?? imageRef;
+  const colonIdx = withoutDigest.lastIndexOf(':');
+  if (colonIdx === -1) return 'latest';
+  const tag = withoutDigest.slice(colonIdx + 1);
+  // If what follows the colon looks like a port (pure integer), it's part of the host
+  if (/^\d+$/.test(tag)) return 'latest';
+  return tag;
+}

--- a/controller/src/notifications/__tests__/session-batcher.test.ts
+++ b/controller/src/notifications/__tests__/session-batcher.test.ts
@@ -139,7 +139,7 @@ describe('session-batcher', () => {
     });
   });
 
-  it('dispatchCheckResults deduplicates same container within 1 hour', () => {
+  it('dispatchCheckResults deduplicates same container within 24 hours', () => {
     const u = uid();
 
     dispatchCheckResults(
@@ -164,6 +164,31 @@ describe('session-batcher', () => {
     vi.advanceTimersByTime(5_000);
     // The container was deduplicated, so the batch had 0 new containers.
     // flushCheckBatch filters out agents with no containers — no dispatch.
+    expect(notifier.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('dispatchCheckResults deduplicates same container even when image changes (rolling :latest)', () => {
+    const u = uid();
+
+    dispatchCheckResults(
+      `agent-1-${u}`,
+      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+      `agent-1-${u}`,
+    );
+
+    vi.advanceTimersByTime(5_000);
+    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+
+    vi.mocked(notifier.dispatch).mockClear();
+
+    // Same container, different image digest / tag — should still be deduped by name
+    dispatchCheckResults(
+      `agent-1-${u}`,
+      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+      `agent-1-${u}`,
+    );
+
+    vi.advanceTimersByTime(5_000);
     expect(notifier.dispatch).not.toHaveBeenCalled();
   });
 

--- a/controller/src/notifications/session-batcher.ts
+++ b/controller/src/notifications/session-batcher.ts
@@ -130,9 +130,10 @@ export function addUpdateResult(agentId: string, result: UpdateResultItem): void
 }
 
 // Deduplicate: track which container updates we already notified about
-// Key: "agentId:containerName:image" → timestamp. Entries expire after 1 hour.
+// Key: "agentId:containerName" → timestamp. Entries expire after 24 hours.
+// Image/digest is intentionally excluded so rolling :latest tags don't bypass dedup.
 const notifiedUpdates = new Map<string, number>();
-const DEDUP_TTL_MS = 60 * 60 * 1000; // 1 hour
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_DEDUP_ENTRIES = 10000;
 
 function pruneNotified(): void {
@@ -259,7 +260,7 @@ export function dispatchCheckResults(
   // Deduplicate: only include containers we haven't notified about yet
   pruneNotified();
   const newContainers = containers.filter((c) => {
-    const key = `${agentId ?? agentName}:${c.name}:${c.image}`;
+    const key = `${agentId ?? agentName}:${c.name}`;
     if (notifiedUpdates.has(key)) return false;
     notifiedUpdates.set(key, Date.now());
     return true;

--- a/controller/src/scheduler/__tests__/engine.test.ts
+++ b/controller/src/scheduler/__tests__/engine.test.ts
@@ -180,6 +180,10 @@ describe('Scheduler', () => {
   it('L2: does NOT run catch-up when last run is recent', async () => {
     await setConfig('check_on_startup', 'true');
     await setConfig('scheduler_last_run', String(Date.now() - 3600000)); // 1h ago
+    // Use a non-firing schedule so the cron does not produce a CHECK message
+    // during the 1.5s observation window (the default * * * * * fires at :00
+    // of each minute and would cause a false positive if the test starts at :59).
+    await setConfig('global_schedule', '0 4 * * *');
 
     mockHub.sentMessages.length = 0;
 

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -127,6 +127,9 @@ export class AgentHub {
   // FIX-1.3: track in-flight auto-update per agent to prevent duplicate UPDATE
   // commands when two CHECK_RESULTs race (e.g. from a reconnect replay).
   private autoUpdateInFlight = new Set<string>();
+  // Cache diffs from CHECK_RESULT keyed by containerId so they can be stored
+  // in update_log when the corresponding UPDATE_RESULT arrives.
+  private pendingDiffs = new Map<string, string | null>();
 
   constructor(broadcaster?: UiBroadcaster) {
     this.broadcaster = broadcaster ?? null;
@@ -300,7 +303,10 @@ export class AgentHub {
                   r.hasUpdate,
                 );
                 // Store image diff if present
-                await updateContainerDiff(r.containerId, r.diff ? JSON.stringify(r.diff) : null);
+                const diffJson = r.diff ? JSON.stringify(r.diff) : null;
+                await updateContainerDiff(r.containerId, diffJson);
+                // Cache for use in update_log when UPDATE_RESULT arrives
+                this.pendingDiffs.set(r.containerId, diffJson);
               }
               await updateAgentStatus(agentId, 'online', Date.now());
               const updatesAvailable = payload.results.filter((r) => r.hasUpdate).length;
@@ -477,6 +483,8 @@ export class AgentHub {
                 },
               ];
               for (const r of results) {
+                const diff = this.pendingDiffs.get(r.containerId) ?? null;
+                this.pendingDiffs.delete(r.containerId);
                 if (r.success && r.newDigest) {
                   // DB-02: log + digest update are atomic — no divergence on crash.
                   await insertUpdateLogAndDigests(
@@ -491,6 +499,7 @@ export class AgentHub {
                       status: isRollback ? 'rolled_back' : 'success',
                       error: r.error,
                       duration_ms: r.durationMs,
+                      diff,
                     },
                     r.containerId,
                     r.newDigest,
@@ -507,6 +516,7 @@ export class AgentHub {
                     status: isRollback ? 'rolled_back' : 'failed',
                     error: r.error,
                     duration_ms: r.durationMs,
+                    diff,
                   });
                 }
               }

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -16,6 +16,7 @@ import {
   listAgentsByTokenPrefix,
   listRegistryCredentials,
   markContainersUnknown,
+  setUpdateFirstSeen,
   updateAgentDockerInfo,
   updateAgentStatus,
   updateContainerDiff,
@@ -295,7 +296,13 @@ export class AgentHub {
                 'hub',
                 `CHECK_RESULT from ${agentId}: ${payload.results.length} results, ${updatesFound} updates`,
               );
+              // Fetch current container state before the loop so we can detect
+              // has_update flips for update_first_seen stamping.
+              const agentContainersPre = await getContainersByAgent(agentId);
               for (const r of payload.results) {
+                const existing = agentContainersPre.find(
+                  (c) => c.docker_id === r.containerId || c.id === r.containerId,
+                );
                 await updateContainerDigests(
                   r.containerId,
                   r.currentDigest ?? '',
@@ -307,6 +314,13 @@ export class AgentHub {
                 await updateContainerDiff(r.containerId, diffJson);
                 // Cache for use in update_log when UPDATE_RESULT arrives
                 this.pendingDiffs.set(r.containerId, diffJson);
+                // Track when an update first becomes visible (for min_age_hours enforcement).
+                const wasUpdate = existing?.has_update === 1;
+                if (r.hasUpdate && !wasUpdate) {
+                  await setUpdateFirstSeen(r.containerId, Date.now());
+                } else if (!r.hasUpdate && wasUpdate) {
+                  await setUpdateFirstSeen(r.containerId, null);
+                }
               }
               await updateAgentStatus(agentId, 'online', Date.now());
               const updatesAvailable = payload.results.filter((r) => r.hasUpdate).length;
@@ -339,8 +353,10 @@ export class AgentHub {
                 this.autoUpdateInFlight.add(agentId);
                 // Auto-update path: send UPDATE, skip "updates available" notification
                 // (update_success/failed notification will follow from UPDATE_RESULT).
-                // Fetch container data to check per-container policies
+                // Fetch container data to check per-container policies.
+                // Re-fetch after the loop so update_first_seen is already written.
                 const agentContainersForUpdate = await getContainersByAgent(agentId);
+                const policy = await getEffectivePolicy(agentId);
                 const globalUpdateLevel = (await getConfig('global_update_level')) ?? '';
                 const containerIds = payload.results
                   .filter((r) => {
@@ -353,6 +369,19 @@ export class AgentHub {
                       return false;
                     // Stateful containers (databases) are never auto-updated
                     if (dbContainer?.is_stateful) return false;
+                    // Min-age gate: skip if the update hasn't been visible long enough
+                    if (policy.min_age_hours > 0) {
+                      const firstSeen = dbContainer?.update_first_seen ?? null;
+                      if (!firstSeen) return false;
+                      const ageMs = Date.now() - firstSeen;
+                      if (ageMs < policy.min_age_hours * 60 * 60 * 1000) {
+                        log.info(
+                          'hub',
+                          `skipping auto-update for ${dbContainer?.name ?? r.containerId}: update too young (${Math.round(ageMs / 3600000)}h < ${policy.min_age_hours}h required)`,
+                        );
+                        return false;
+                      }
+                    }
                     // Semver level enforcement: per-container takes precedence over global
                     const effectiveLevel = dbContainer?.update_level || globalUpdateLevel;
                     if (effectiveLevel && effectiveLevel !== 'all') {
@@ -378,7 +407,6 @@ export class AgentHub {
                   this.autoUpdateInFlight.delete(agentId);
                   break;
                 }
-                const policy = await getEffectivePolicy(agentId);
                 this.sendToAgent(agentId, {
                   type: 'UPDATE',
                   payload: {
@@ -396,7 +424,7 @@ export class AgentHub {
                 });
               } else if (updatesAvailable > 0) {
                 // Notification path: auto-update is OFF, notify the operator.
-                const agentContainers = await getContainersByAgent(agentId);
+                const agentContainers = agentContainersPre;
                 const withUpdates = payload.results
                   .filter((r) => r.hasUpdate)
                   .map((r) => {

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -66,6 +66,8 @@ interface UpdateResultItem {
   success: boolean;
   oldDigest: string | null;
   newDigest: string | null;
+  oldImage?: string | null;
+  newImage?: string | null;
   error: string | null;
   durationMs: number;
 }
@@ -428,6 +430,8 @@ export class AgentHub {
                 success?: boolean;
                 oldDigest?: string;
                 newDigest?: string;
+                oldImage?: string;
+                newImage?: string;
                 error?: string;
                 durationMs?: number;
                 isRollback?: boolean;
@@ -447,6 +451,8 @@ export class AgentHub {
                   success: payload.success ?? false,
                   oldDigest: payload.oldDigest ?? null,
                   newDigest: payload.newDigest ?? null,
+                  oldImage: payload.oldImage ?? null,
+                  newImage: payload.newImage ?? null,
                   error: payload.error ?? null,
                   durationMs: payload.durationMs ?? 0,
                 },
@@ -461,6 +467,8 @@ export class AgentHub {
                       container_name: r.containerName,
                       old_digest: r.oldDigest,
                       new_digest: r.newDigest,
+                      old_image: r.oldImage ?? null,
+                      new_image: r.newImage ?? null,
                       status: isRollback ? 'rolled_back' : 'success',
                       error: r.error,
                       duration_ms: r.durationMs,
@@ -475,6 +483,8 @@ export class AgentHub {
                     container_name: r.containerName,
                     old_digest: r.oldDigest,
                     new_digest: r.newDigest,
+                    old_image: r.oldImage ?? null,
+                    new_image: r.newImage ?? null,
                     status: isRollback ? 'rolled_back' : 'failed',
                     error: r.error,
                     duration_ms: r.durationMs,

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -25,6 +25,7 @@ import {
 } from '../db/queries.js';
 import { decrypt } from '../lib/crypto.js';
 import { log } from '../lib/logger.js';
+import { extractTag, semverMatchesLevel } from '../lib/semver.js';
 import { addUpdateResult, dispatchCheckResults } from '../notifications/session-batcher.js';
 import type { ContainerInfo } from '../types.js';
 import type { UiBroadcaster } from './ui-broadcaster.js';
@@ -332,6 +333,7 @@ export class AgentHub {
                 // (update_success/failed notification will follow from UPDATE_RESULT).
                 // Fetch container data to check per-container policies
                 const agentContainersForUpdate = await getContainersByAgent(agentId);
+                const globalUpdateLevel = (await getConfig('global_update_level')) ?? '';
                 const containerIds = payload.results
                   .filter((r) => {
                     if (!r.hasUpdate) return false;
@@ -343,6 +345,23 @@ export class AgentHub {
                       return false;
                     // Stateful containers (databases) are never auto-updated
                     if (dbContainer?.is_stateful) return false;
+                    // Semver level enforcement: per-container takes precedence over global
+                    const effectiveLevel = dbContainer?.update_level || globalUpdateLevel;
+                    if (effectiveLevel && effectiveLevel !== 'all') {
+                      const currentTag = extractTag(dbContainer?.image ?? '');
+                      const candidateTag = extractTag(r.latestDigest ?? '');
+                      // Only enforce when both sides have parseable tags (not sha256 digests)
+                      if (currentTag && candidateTag) {
+                        if (!semverMatchesLevel(currentTag, candidateTag, effectiveLevel)) {
+                          log.info(
+                            'hub',
+                            `skipping auto-update for ${dbContainer?.name ?? r.containerId}: ` +
+                              `${currentTag} → ${candidateTag} blocked by update_level=${effectiveLevel}`,
+                          );
+                          return false;
+                        }
+                      }
+                    }
                     return true;
                   })
                   .map((r) => r.containerId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
     },
     "controller": {
       "name": "watchwarden-controller",
-      "version": "0.0.1",
+      "version": "0.2.1",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/cors": "^10.0.1",
@@ -12104,7 +12104,7 @@
       }
     },
     "ui": {
-      "version": "0.0.1",
+      "version": "0.2.1",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,7 @@ export interface Container {
   tag_pattern: string | null;
   update_level: string | null;
   is_stateful: number;
+  update_first_seen: number | null;
 }
 
 export interface ContainerInfo {
@@ -119,6 +120,7 @@ export interface UpdatePolicy {
   auto_rollback_enabled: boolean;
   max_unhealthy_seconds: number;
   strategy: string;
+  min_age_hours: number;
   created_at: number;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -94,6 +94,7 @@ export interface UpdateLog {
   status: 'success' | 'failed' | 'rolled_back';
   error: string | null;
   duration_ms: number | null;
+  diff: string | null;
   created_at: number;
 }
 
@@ -108,6 +109,7 @@ export interface NewUpdateLog {
   status: 'success' | 'failed' | 'rolled_back';
   error?: string | null;
   duration_ms?: number | null;
+  diff?: string | null;
 }
 
 export interface UpdatePolicy {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,10 +84,13 @@ export interface AgentConfigUpdate {
 export interface UpdateLog {
   id: number;
   agent_id: string;
+  agent_name: string | null;
   container_id: string;
   container_name: string;
   old_digest: string | null;
   new_digest: string | null;
+  old_image: string | null;
+  new_image: string | null;
   status: 'success' | 'failed' | 'rolled_back';
   error: string | null;
   duration_ms: number | null;
@@ -100,6 +103,8 @@ export interface NewUpdateLog {
   container_name: string;
   old_digest?: string | null;
   new_digest?: string | null;
+  old_image?: string | null;
+  new_image?: string | null;
   status: 'success' | 'failed' | 'rolled_back';
   error?: string | null;
   duration_ms?: number | null;

--- a/ui/src/api/hooks/useAgents.ts
+++ b/ui/src/api/hooks/useAgents.ts
@@ -184,6 +184,31 @@ export function useContainerLogs(
   });
 }
 
+export function useUpdateContainerPolicy() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      agentId,
+      containerId,
+      policy,
+      updateLevel,
+    }: {
+      agentId: string;
+      containerId: string;
+      policy: string | null;
+      updateLevel: string | null;
+    }) =>
+      apiRequest<void>(`/agents/${agentId}/containers/${containerId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ policy, update_level: updateLevel }),
+      }),
+    onSuccess: (_, { agentId }) => {
+      queryClient.invalidateQueries({ queryKey: ['agents'] });
+      queryClient.invalidateQueries({ queryKey: ['agents', agentId] });
+    },
+  });
+}
+
 export function useUpdateAgentConfig() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/ui/src/api/hooks/usePolicies.ts
+++ b/ui/src/api/hooks/usePolicies.ts
@@ -21,6 +21,7 @@ export function useUpdatePolicyMutation() {
       autoRollbackEnabled?: boolean;
       maxUnhealthySeconds?: number;
       strategy?: string;
+      minAgeHours?: number;
     }) =>
       apiRequest<void>('/update-policies', {
         method: 'PUT',

--- a/ui/src/components/__tests__/AgentCard.test.tsx
+++ b/ui/src/components/__tests__/AgentCard.test.tsx
@@ -42,6 +42,7 @@ const mockAgent: Agent = {
       tag_pattern: null,
       update_level: null,
       is_stateful: 0,
+      update_first_seen: Date.now(),
     },
     {
       id: 'c-2',
@@ -67,6 +68,7 @@ const mockAgent: Agent = {
       tag_pattern: null,
       update_level: null,
       is_stateful: 0,
+      update_first_seen: Date.now(),
     },
   ],
 };

--- a/ui/src/components/__tests__/AgentCard.test.tsx
+++ b/ui/src/components/__tests__/AgentCard.test.tsx
@@ -13,6 +13,7 @@ const mockAgent: Agent = {
   auto_update: 0,
   docker_version: null,
   docker_api_version: null,
+  agent_version: null,
   os: null,
   arch: null,
   created_at: Date.now(),
@@ -40,6 +41,7 @@ const mockAgent: Agent = {
       policy: null,
       tag_pattern: null,
       update_level: null,
+      is_stateful: 0,
     },
     {
       id: 'c-2',
@@ -64,6 +66,7 @@ const mockAgent: Agent = {
       policy: null,
       tag_pattern: null,
       update_level: null,
+      is_stateful: 0,
     },
   ],
 };

--- a/ui/src/components/__tests__/AgentCard.test.tsx
+++ b/ui/src/components/__tests__/AgentCard.test.tsx
@@ -42,7 +42,7 @@ const mockAgent: Agent = {
       tag_pattern: null,
       update_level: null,
       is_stateful: 0,
-      update_first_seen: Date.now(),
+      update_first_seen: null,
     },
     {
       id: 'c-2',
@@ -68,7 +68,7 @@ const mockAgent: Agent = {
       tag_pattern: null,
       update_level: null,
       is_stateful: 0,
-      update_first_seen: Date.now(),
+      update_first_seen: null,
     },
   ],
 };

--- a/ui/src/components/__tests__/ContainerRow.test.tsx
+++ b/ui/src/components/__tests__/ContainerRow.test.tsx
@@ -28,6 +28,7 @@ const baseContainer: Container = {
   policy: null,
   tag_pattern: null,
   update_level: null,
+  is_stateful: 0,
 };
 
 const queryClient = new QueryClient({

--- a/ui/src/components/__tests__/ContainerRow.test.tsx
+++ b/ui/src/components/__tests__/ContainerRow.test.tsx
@@ -29,6 +29,7 @@ const baseContainer: Container = {
   tag_pattern: null,
   update_level: null,
   is_stateful: 0,
+  update_first_seen: null,
 };
 
 const queryClient = new QueryClient({

--- a/ui/src/components/agents/ContainerRow.tsx
+++ b/ui/src/components/agents/ContainerRow.tsx
@@ -3,6 +3,7 @@ import {
   Ban,
   Database,
   Loader2,
+  Pencil,
   Pin,
   Play,
   RefreshCw,
@@ -18,6 +19,7 @@ import {
   useContainerDelete,
   useContainerStart,
   useContainerStop,
+  useUpdateContainerPolicy,
 } from '@/api/hooks/useAgents';
 import { ContainerLogsDialog } from '@/components/agents/ContainerLogsDialog';
 import { DigestBadge } from '@/components/common/DigestBadge';
@@ -38,12 +40,15 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useStore } from '@/store/useStore';
 
@@ -80,6 +85,9 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
   const [rollbackOpen, setRollbackOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
+  const [policyOpen, setPolicyOpen] = useState(false);
+  const [editPolicy, setEditPolicy] = useState<string>(container.policy ?? 'auto');
+  const [editLevel, setEditLevel] = useState<string>(container.update_level ?? '');
   const [pendingAction, setPendingAction] = useState<'start' | 'stop' | 'delete' | 'check' | null>(
     null,
   );
@@ -91,6 +99,7 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
   const startContainer = useContainerStart();
   const stopContainer = useContainerStop();
   const deleteContainer = useContainerDelete();
+  const updatePolicy = useUpdateContainerPolicy();
 
   const hasUpdate = container.has_update === 1;
   const isExcluded = container.excluded === 1;
@@ -238,44 +247,152 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
               </Tooltip>
             </TooltipProvider>
           )}
-          {container.policy && container.policy !== 'auto' && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger render={<span />} className="cursor-default">
-                  <Badge
-                    variant="outline"
-                    className={`text-[10px] px-1.5 py-0 ${
-                      container.policy === 'manual'
-                        ? 'border-muted-foreground text-muted-foreground'
-                        : 'border-primary/30 text-primary'
-                    }`}
+          {/* Policy / update-level — click pencil to edit */}
+          <Dialog
+            open={policyOpen}
+            onOpenChange={(open) => {
+              setPolicyOpen(open);
+              if (open) {
+                setEditPolicy(container.policy ?? 'auto');
+                setEditLevel(container.update_level ?? '');
+              }
+            }}
+          >
+            <div className="flex items-center gap-1">
+              {container.policy && container.policy !== 'auto' && (
+                <Badge
+                  variant="outline"
+                  className={`text-[10px] px-1.5 py-0 ${
+                    container.policy === 'manual'
+                      ? 'border-muted-foreground text-muted-foreground'
+                      : 'border-primary/30 text-primary'
+                  }`}
+                >
+                  {container.policy === 'manual' ? 'MANUAL' : 'NOTIFY'}
+                </Badge>
+              )}
+              {container.update_level && container.update_level !== 'all' && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] px-1.5 py-0 border-violet-400/40 text-violet-500"
+                >
+                  {container.update_level.toUpperCase()}
+                </Badge>
+              )}
+              {container.tag_pattern && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger render={<span />} className="cursor-default">
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] px-1.5 py-0 border-blue-400/30 text-blue-500"
+                      >
+                        TAG
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>Tag pattern: {container.tag_pattern}</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
+              <DialogTrigger
+                render={
+                  <button
+                    type="button"
+                    className="opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity cursor-pointer"
+                    aria-label="Edit policy"
+                  />
+                }
+              >
+                <Pencil size={11} className="text-muted-foreground" />
+              </DialogTrigger>
+            </div>
+
+            <DialogContent className="max-w-sm">
+              <DialogHeader>
+                <DialogTitle>Update policy — {container.name}</DialogTitle>
+                <DialogDescription>
+                  Override how this container is treated during auto-updates.
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-4 py-2">
+                <div className="space-y-2">
+                  <p className="text-sm font-medium">Policy</p>
+                  <div className="flex flex-col gap-1.5">
+                    {(['auto', 'notify', 'manual'] as const).map((p) => (
+                      <label
+                        key={p}
+                        htmlFor={`policy-${p}`}
+                        className="flex items-center gap-2 cursor-pointer text-sm"
+                      >
+                        <input
+                          id={`policy-${p}`}
+                          type="radio"
+                          name="policy"
+                          value={p}
+                          checked={editPolicy === p}
+                          onChange={() => setEditPolicy(p)}
+                          className="w-4 h-4 cursor-pointer"
+                        />
+                        <span>
+                          {p === 'auto' && 'Auto — follow agent / global setting'}
+                          {p === 'notify' && 'Notify only — never auto-update'}
+                          {p === 'manual' && 'Manual — skip checks entirely'}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="edit-update-level">Max update level</Label>
+                  <select
+                    id="edit-update-level"
+                    value={editLevel}
+                    onChange={(e) => setEditLevel(e.target.value)}
+                    disabled={editPolicy === 'manual'}
+                    className="w-full px-3 py-2 rounded-md bg-card border border-border text-sm text-foreground disabled:opacity-50"
                   >
-                    {container.policy === 'manual' ? 'MANUAL' : 'NOTIFY'}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {container.policy === 'manual'
-                    ? 'Updates managed manually — set via com.watchwarden.policy=manual'
-                    : 'Notify only — set via com.watchwarden.policy=notify'}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          {container.tag_pattern && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger render={<span />} className="cursor-default">
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] px-1.5 py-0 border-blue-400/30 text-blue-500"
-                  >
-                    TAG
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>Tag pattern: {container.tag_pattern}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
+                    <option value="">Default (inherit global)</option>
+                    <option value="all">All versions</option>
+                    <option value="major">Major+minor+patch</option>
+                    <option value="minor">Minor+patch only</option>
+                    <option value="patch">Patch only</option>
+                  </select>
+                  <p className="text-xs text-muted-foreground">
+                    Only applies to semver-tagged images (e.g. 1.2.3).
+                  </p>
+                </div>
+              </div>
+
+              <DialogFooter>
+                <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+                <Button
+                  disabled={updatePolicy.isPending}
+                  onClick={() => {
+                    updatePolicy.mutate(
+                      {
+                        agentId,
+                        containerId: container.id,
+                        policy: editPolicy === 'auto' ? null : editPolicy,
+                        updateLevel: editLevel || null,
+                      },
+                      {
+                        onSuccess: () => setPolicyOpen(false),
+                        onError: (err) =>
+                          addToast({
+                            type: 'error',
+                            message: `Failed to save policy: ${err instanceof Error ? err.message : String(err)}`,
+                          }),
+                      },
+                    );
+                  }}
+                >
+                  {updatePolicy.isPending ? <Loader2 size={14} className="animate-spin" /> : 'Save'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
           {hasUpdate && !isExcluded && !isPinned && (
             <Badge className="bg-warning/15 text-warning border-warning/30 text-[10px] px-1.5 py-0">
               UPDATE

--- a/ui/src/components/agents/ContainerRow.tsx
+++ b/ui/src/components/agents/ContainerRow.tsx
@@ -2,6 +2,7 @@ import {
   ArrowUpCircle,
   Ban,
   Database,
+  Info,
   Loader2,
   Pin,
   Play,
@@ -20,7 +21,6 @@ import {
   useContainerStop,
 } from '@/api/hooks/useAgents';
 import { ContainerLogsDialog } from '@/components/agents/ContainerLogsDialog';
-import { DigestBadge } from '@/components/common/DigestBadge';
 import { DiffBadge, type ImageDiff, ImageDiffView } from '@/components/diff/ImageDiffView';
 import { VersionPickerModal } from '@/components/rollback/VersionPickerModal';
 import {
@@ -313,29 +313,38 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
             </Badge>
           )}
         </div>
-        <p className="text-xs text-muted-foreground truncate mt-0.5">
-          {container.image}
-          {container.depends_on &&
-            (() => {
-              try {
-                const deps = JSON.parse(container.depends_on) as string[];
-                if (deps.length > 0)
-                  return (
-                    <span className="ml-2 text-muted-foreground/60">
-                      depends on: {deps.join(', ')}
-                    </span>
-                  );
-              } catch {
-                /* ignore */
-              }
-              return null;
-            })()}
-        </p>
-      </div>
-
-      {/* Digest */}
-      <div className="hidden lg:block shrink-0">
-        <DigestBadge digest={container.current_digest} />
+        <div className="flex items-center gap-1 mt-0.5 min-w-0">
+          <p className="text-xs text-muted-foreground truncate">
+            {container.image}
+            {container.depends_on &&
+              (() => {
+                try {
+                  const deps = JSON.parse(container.depends_on) as string[];
+                  if (deps.length > 0)
+                    return (
+                      <span className="ml-2 text-muted-foreground/60">
+                        depends on: {deps.join(', ')}
+                      </span>
+                    );
+                } catch {
+                  /* ignore */
+                }
+                return null;
+              })()}
+          </p>
+          {container.current_digest && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger render={<span />} className="cursor-help shrink-0">
+                  <Info size={12} className="text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-none">
+                  <span className="font-mono break-all">{container.current_digest}</span>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
       </div>
 
       {/* Actions */}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -474,7 +474,7 @@ function StabilityPolicyCard({ agentId }: { agentId: string }) {
           />
           <Label>Auto-rollback on unhealthy</Label>
         </div>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
           <div className="space-y-1">
             <Label className="text-xs text-muted-foreground">Stability window (seconds)</Label>
             <Input
@@ -497,6 +497,22 @@ function StabilityPolicyCard({ agentId }: { agentId: string }) {
                 updatePolicy.mutate({
                   scope: `agent:${agentId}`,
                   maxUnhealthySeconds: Number(e.target.value),
+                })
+              }
+            />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">
+              Min age before auto-update (hours)
+            </Label>
+            <Input
+              type="number"
+              min={0}
+              defaultValue={policy.min_age_hours ?? 0}
+              onBlur={(e) =>
+                updatePolicy.mutate({
+                  scope: `agent:${agentId}`,
+                  minAgeHours: Number(e.target.value),
                 })
               }
             />

--- a/ui/src/pages/History.tsx
+++ b/ui/src/pages/History.tsx
@@ -4,8 +4,16 @@ import { Fragment, useState } from 'react';
 import { useHistory, useHistoryStats } from '@/api/hooks/useHistory';
 import { DigestBadge } from '@/components/common/DigestBadge';
 import { Pagination } from '@/components/common/Pagination';
+import { DiffBadge, type ImageDiff, ImageDiffView } from '@/components/diff/ImageDiffView';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -131,12 +139,20 @@ export function HistoryPage() {
             )}
             {history?.data.map((entry) => {
               const isExpanded = expandedRows.has(entry.id);
+              const parsedDiff: ImageDiff | null = entry.diff
+                ? (() => {
+                    try {
+                      return JSON.parse(entry.diff) as ImageDiff;
+                    } catch {
+                      return null;
+                    }
+                  })()
+                : null;
               const hasDetails = !!(
                 entry.old_digest ||
                 entry.new_digest ||
-                entry.old_image ||
-                entry.new_image ||
-                entry.error
+                entry.error ||
+                parsedDiff
               );
               return (
                 <Fragment key={entry.id}>
@@ -204,6 +220,26 @@ export function HistoryPage() {
                             <>
                               <span className="text-muted-foreground">Error</span>
                               <span className="text-destructive break-all">{entry.error}</span>
+                            </>
+                          )}
+                          {parsedDiff && (
+                            <>
+                              <span className="text-muted-foreground">Image diff</span>
+                              <Dialog>
+                                <DialogTrigger
+                                  render={<button type="button" className="w-fit cursor-pointer" />}
+                                >
+                                  <DiffBadge diff={parsedDiff} />
+                                </DialogTrigger>
+                                <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+                                  <DialogHeader>
+                                    <DialogTitle>
+                                      Image changes — {entry.container_name}
+                                    </DialogTitle>
+                                  </DialogHeader>
+                                  <ImageDiffView diff={parsedDiff} />
+                                </DialogContent>
+                              </Dialog>
                             </>
                           )}
                         </div>

--- a/ui/src/pages/History.tsx
+++ b/ui/src/pages/History.tsx
@@ -1,5 +1,5 @@
 import { formatDistanceToNow } from 'date-fns';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Info } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import { useHistory, useHistoryStats } from '@/api/hooks/useHistory';
 import { DigestBadge } from '@/components/common/DigestBadge';
@@ -15,6 +15,35 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+function ImageVersionLabel({ image, digest }: { image: string | null; digest: string | null }) {
+  if (!image && !digest) return <span className="text-muted-foreground">—</span>;
+
+  // For old records without image tag, extract name from "image@sha256:hash" digest format
+  const label = image ?? (digest?.includes('@sha256:') ? digest.split('@sha256:')[0] : null);
+
+  if (label) {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-xs">
+        {label}
+        {digest && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger render={<span />} className="cursor-help inline-flex shrink-0">
+                <Info size={12} className="text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-none">
+                <span className="font-mono break-all">{digest}</span>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </span>
+    );
+  }
+  return <DigestBadge digest={digest} />;
+}
 
 export function HistoryPage() {
   const [agentFilter, setAgentFilter] = useState('');
@@ -102,7 +131,13 @@ export function HistoryPage() {
             )}
             {history?.data.map((entry) => {
               const isExpanded = expandedRows.has(entry.id);
-              const hasDetails = !!(entry.old_digest || entry.new_digest || entry.error);
+              const hasDetails = !!(
+                entry.old_digest ||
+                entry.new_digest ||
+                entry.old_image ||
+                entry.new_image ||
+                entry.error
+              );
               return (
                 <Fragment key={entry.id}>
                   <TableRow
@@ -121,7 +156,7 @@ export function HistoryPage() {
                       {formatDistanceToNow(entry.created_at, { addSuffix: true })}
                     </TableCell>
                     <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                      {entry.agent_id}
+                      {entry.agent_name ?? entry.agent_id}
                     </TableCell>
                     <TableCell className="text-sm">{entry.container_name}</TableCell>
                     <TableCell>
@@ -141,16 +176,22 @@ export function HistoryPage() {
                       <TableCell />
                       <TableCell colSpan={5} className="bg-muted/30 py-3">
                         <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-xs font-mono">
-                          {entry.old_digest && (
+                          {(entry.old_digest || entry.old_image) && (
                             <>
-                              <span className="text-muted-foreground">Old digest</span>
-                              <DigestBadge digest={entry.old_digest} />
+                              <span className="text-muted-foreground">Old version</span>
+                              <ImageVersionLabel
+                                image={entry.old_image ?? null}
+                                digest={entry.old_digest ?? null}
+                              />
                             </>
                           )}
-                          {entry.new_digest && (
+                          {(entry.new_digest || entry.new_image) && (
                             <>
-                              <span className="text-muted-foreground">New digest</span>
-                              <DigestBadge digest={entry.new_digest} />
+                              <span className="text-muted-foreground">New version</span>
+                              <ImageVersionLabel
+                                image={entry.new_image ?? null}
+                                digest={entry.new_digest ?? null}
+                              />
                             </>
                           )}
                           {entry.duration_ms && (

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -126,6 +126,45 @@ function GeneralTab() {
 
       <Card>
         <CardHeader>
+          <CardTitle>Default Update Level</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">Maximum allowed update level</p>
+              <p className="text-xs text-muted-foreground">
+                Global default for containers without a per-container update level set. Limits how
+                far semver-tagged images can be updated.
+              </p>
+            </div>
+            <select
+              className="text-sm border rounded px-2 py-1 bg-background"
+              value={config?.global_update_level ?? ''}
+              onChange={(e) =>
+                updateConfig.mutate(
+                  { key: 'global_update_level', value: e.target.value },
+                  {
+                    onError: () =>
+                      addToast({
+                        type: 'error',
+                        message: 'Failed to update setting',
+                      }),
+                  },
+                )
+              }
+            >
+              <option value="">Any (no restriction)</option>
+              <option value="all">All versions</option>
+              <option value="major">Major only</option>
+              <option value="minor">Minor only</option>
+              <option value="patch">Patch only</option>
+            </select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
           <CardTitle>Admin Password</CardTitle>
         </CardHeader>
         <CardContent>

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -64,6 +64,10 @@ Each container row shows:
 - **Action buttons** — Check, Update, Rollback, View Logs, Start/Stop, Delete
 - **Container labels** — policy, tag pattern, update group, pinned version, and exclusion status
 
+Click the pencil icon next to the policy badge to edit the container's update policy and semver update level directly from the UI (no label changes required):
+- **Policy** — Auto (follow global), Notify only, or Manual (skip checks)
+- **Max update level** — restrict updates to Patch, Minor, or Major semver bumps
+
 The **Containers** and **Configuration** tabs let you switch between the container list and agent-specific settings.
 
 ### Agent Configuration
@@ -123,6 +127,7 @@ Configure global update schedule, startup behavior, admin password, and agent re
 />
 
 - **Global Schedule** — cron expression picker with presets (hourly, daily, weekly)
+- **Default Update Level** — global semver cap (`patch`, `minor`, `major`, or no restriction) applied to all containers without a per-container level set
 - **Check on startup** — catch-up check if the last scheduled check was more than 24 hours ago
 - **Admin Password** — change the dashboard login password
 - **Recovery Mode** — time-limited window for automatic agent re-registration after database loss (see below)

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -100,6 +100,7 @@ Full audit trail of every container update, rollback, and failure across all age
 
 Features:
 - **Expandable rows** — click to reveal old/new digests, duration, and error messages
+- **Image diff badge** — if the update had configuration changes (env, ports, entrypoint, volumes), a diff badge appears in the expanded row; click it to open the full diff view
 - **Filters** — by agent ID and status (success, failed, rolled back)
 - **Pagination** — browse through all historical updates
 - **Success rate** — overall success percentage displayed at the top

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -82,7 +82,7 @@ The Configuration tab provides per-agent settings that override the global defau
 
 - **Schedule Override** — set a custom cron schedule for this agent (overrides the global schedule)
 - **Auto Update** — enable automatic updates when new images are detected
-- **Stability & Auto Rollback** — configure the health monitoring window and automatic rollback behavior after updates
+- **Stability & Auto Rollback** — configure health monitoring window, automatic rollback, and minimum update age (hold back auto-updates until a new image has been available for N hours)
 - **Update Strategy** — choose between stop-first (default) or start-first (blue-green) deployment
 - **Image Pruning** — clean up old images after successful updates to reclaim disk space
 

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -100,7 +100,6 @@ Full audit trail of every container update, rollback, and failure across all age
 
 Features:
 - **Expandable rows** — click to reveal old/new digests, duration, and error messages
-- **Image diff badge** — if the update had configuration changes (env, ports, entrypoint, volumes), a diff badge appears in the expanded row; click it to open the full diff view
 - **Filters** — by agent ID and status (success, failed, rolled back)
 - **Pagination** — browse through all historical updates
 - **Success rate** — overall success percentage displayed at the top


### PR DESCRIPTION
## Summary

This release brings a batch of Phase 1 and Phase 2 features improving update visibility, policy control, monitoring, and observability.

### `fix/show-concrete-image-tags`
- Persists `old_image` / `new_image` (e.g. `postgres:latest`) alongside SHA256 digests in `update_log`
- History UI and agent notifications now show human-readable image references instead of raw digests

### `feat/phase1-semver-policy-ui`
- Adds semver update-level enforcement (`major`, `minor`, `patch`, `any`) per container and globally
- Per-container policy dialog in the Agent Detail container table
- Global default update level selector in Settings → General

### `feat/phase1-diff-history`
- Persists a structured diff (added/removed layers, size delta) with every update log entry
- History UI expands rows to show what changed between old and new image

### `feat/phase2-metrics`
- Adds `/metrics` Prometheus endpoint with per-container labeled gauges:
  - `watchwarden_container_info` — image, agent, container labels
  - `watchwarden_container_has_update` — 0/1 update available
  - `watchwarden_container_last_updated_ms` — Unix ms timestamp of last update

### `feat/phase2-monitor-only`
- Agent-side 1-minute cooldown for repeated failure notifications (prevents alert storms)
- Controller-side update-available dedup TTL extended from 1 h → 24 h; dedup key now ignores image tag changes for rolling `:latest` containers
- Fix: flaky scheduler test race condition when `* * * * *` fires within the 1.5 s observation window

### `feat/phase2-aging`
- Adds `min_age_hours` to update policies — auto-updates are held back until an update has been available for at least N hours
- Stamps `update_first_seen` on `containers` table when `has_update` first flips to 1; clears on successful update
- UI: "Min age before auto-update" input in Agent Configuration → Stability card

---

