### PR TITLE
fix: preserve per-container policy on agent heartbeat upsert

### DIFF
--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -150,9 +150,9 @@ export async function upsertContainers(
       update_group = EXCLUDED.update_group,
       update_priority = EXCLUDED.update_priority,
       depends_on = EXCLUDED.depends_on,
-      policy = EXCLUDED.policy,
-      tag_pattern = EXCLUDED.tag_pattern,
-      update_level = EXCLUDED.update_level,
+      policy = COALESCE(EXCLUDED.policy, containers.policy),
+      tag_pattern = COALESCE(EXCLUDED.tag_pattern, containers.tag_pattern),
+      update_level = COALESCE(EXCLUDED.update_level, containers.update_level),
       health_status = COALESCE(EXCLUDED.health_status, containers.health_status),
       is_stateful = EXCLUDED.is_stateful
   `;


### PR DESCRIPTION
Fixes #28

## Summary

- `COALESCE(EXCLUDED.policy, containers.policy)` — never overwrite a saved policy with `null` from an agent heartbeat
- Same applied to `tag_pattern` and `update_level`
- Consistent with the existing `COALESCE` pattern already used for `health_status` in the same query

## Root cause

`upsertContainers` runs on every agent heartbeat. The agent sends `policy: null` for all containers (it has no knowledge of controller-side policy settings). The `ON CONFLICT DO UPDATE SET` was unconditionally writing `EXCLUDED.policy`, resetting any value saved via `PATCH /api/agents/:id/containers/:id` on the very next heartbeat cycle.

## Test plan

- [ ] Set a per-container policy (e.g. `manual`) via the UI policy dialog
- [ ] Trigger a check / wait for the next scheduled heartbeat
- [ ] Confirm the policy is still shown correctly after the heartbeat
- [ ] Run controller tests: `cd controller && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)