### PR TITLE
refactor: extract shared UpdateLogTable component

### DIFF
--- a/ui/src/components/history/UpdateLogTable.tsx
+++ b/ui/src/components/history/UpdateLogTable.tsx
@@ -1,0 +1,220 @@
+import { formatDistanceToNow } from 'date-fns';
+import { ChevronDown, ChevronRight, Info } from 'lucide-react';
+import { Fragment, useState } from 'react';
+import type { UpdateLogEntry } from '@/api/hooks/useHistory';
+import { DigestBadge } from '@/components/common/DigestBadge';
+import { DiffBadge, type ImageDiff, ImageDiffView } from '@/components/diff/ImageDiffView';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+function ImageVersionLabel({ image, digest }: { image: string | null; digest: string | null }) {
+  if (!image && !digest) return <span className="text-muted-foreground">—</span>;
+
+  const label = image ?? (digest?.includes('@sha256:') ? digest.split('@sha256:')[0] : null);
+
+  if (label) {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-xs">
+        {label}
+        {digest && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger render={<span />} className="cursor-help inline-flex shrink-0">
+                <Info size={12} className="text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-none">
+                <span className="font-mono break-all">{digest}</span>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </span>
+    );
+  }
+  return <DigestBadge digest={digest} />;
+}
+
+interface UpdateLogTableProps {
+  entries: UpdateLogEntry[];
+  emptyMessage?: string;
+}
+
+export function UpdateLogTable({
+  entries,
+  emptyMessage = 'No history entries',
+}: UpdateLogTableProps) {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+
+  const toggleRow = (id: number) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (entries.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground text-sm">
+          {emptyMessage}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-8" />
+            <TableHead className="hidden sm:table-cell">Time</TableHead>
+            <TableHead className="hidden md:table-cell">Agent</TableHead>
+            <TableHead>Container</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="hidden md:table-cell">Duration</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => {
+            const isExpanded = expandedRows.has(entry.id);
+            const parsedDiff: ImageDiff | null = entry.diff
+              ? (() => {
+                  try {
+                    return JSON.parse(entry.diff) as ImageDiff;
+                  } catch {
+                    return null;
+                  }
+                })()
+              : null;
+            const hasDetails = !!(
+              entry.old_digest ||
+              entry.new_digest ||
+              entry.old_image ||
+              entry.new_image ||
+              entry.error ||
+              parsedDiff
+            );
+
+            return (
+              <Fragment key={entry.id}>
+                <TableRow
+                  className={hasDetails ? 'cursor-pointer hover:bg-muted/50' : ''}
+                  onClick={() => hasDetails && toggleRow(entry.id)}
+                >
+                  <TableCell className="w-8 pr-0">
+                    {hasDetails &&
+                      (isExpanded ? (
+                        <ChevronDown size={14} className="text-muted-foreground" />
+                      ) : (
+                        <ChevronRight size={14} className="text-muted-foreground" />
+                      ))}
+                  </TableCell>
+                  <TableCell className="hidden sm:table-cell text-sm text-muted-foreground whitespace-nowrap">
+                    {formatDistanceToNow(entry.created_at, { addSuffix: true })}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
+                    {entry.agent_name ?? entry.agent_id}
+                  </TableCell>
+                  <TableCell className="text-sm">{entry.container_name}</TableCell>
+                  <TableCell>
+                    <Badge
+                      variant={entry.status === 'success' ? 'outline' : 'destructive'}
+                      className={
+                        entry.status === 'success'
+                          ? 'border-success text-success'
+                          : entry.status === 'rolled_back'
+                            ? 'border-primary/30 text-primary'
+                            : ''
+                      }
+                    >
+                      {entry.status === 'rolled_back' ? 'rollback' : entry.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
+                    {entry.duration_ms ? `${(entry.duration_ms / 1000).toFixed(1)}s` : '—'}
+                  </TableCell>
+                </TableRow>
+                {isExpanded && hasDetails && (
+                  <TableRow>
+                    <TableCell />
+                    <TableCell colSpan={5} className="bg-muted/30 py-3">
+                      <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-xs font-mono">
+                        {(entry.old_digest || entry.old_image) && (
+                          <>
+                            <span className="text-muted-foreground">Old version</span>
+                            <ImageVersionLabel
+                              image={entry.old_image ?? null}
+                              digest={entry.old_digest ?? null}
+                            />
+                          </>
+                        )}
+                        {(entry.new_digest || entry.new_image) && (
+                          <>
+                            <span className="text-muted-foreground">New version</span>
+                            <ImageVersionLabel
+                              image={entry.new_image ?? null}
+                              digest={entry.new_digest ?? null}
+                            />
+                          </>
+                        )}
+                        {entry.duration_ms && (
+                          <>
+                            <span className="text-muted-foreground">Duration</span>
+                            <span>{(entry.duration_ms / 1000).toFixed(1)}s</span>
+                          </>
+                        )}
+                        {entry.error && (
+                          <>
+                            <span className="text-muted-foreground">Error</span>
+                            <span className="text-destructive break-all">{entry.error}</span>
+                          </>
+                        )}
+                        {parsedDiff && (
+                          <>
+                            <span className="text-muted-foreground">Image diff</span>
+                            <Dialog>
+                              <DialogTrigger
+                                render={<button type="button" className="w-fit cursor-pointer" />}
+                              >
+                                <DiffBadge diff={parsedDiff} />
+                              </DialogTrigger>
+                              <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+                                <DialogHeader>
+                                  <DialogTitle>Image changes — {entry.container_name}</DialogTitle>
+                                </DialogHeader>
+                                <ImageDiffView diff={parsedDiff} />
+                              </DialogContent>
+                            </Dialog>
+                          </>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Card>
+  );
+}

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -1,35 +1,15 @@
-import { formatDistanceToNow } from 'date-fns';
-import {
-  ArrowUpCircle,
-  CheckCircle,
-  ChevronDown,
-  ChevronRight,
-  Hexagon,
-  LayoutGrid,
-  List,
-  RefreshCw,
-  RotateCcw,
-  XCircle,
-} from 'lucide-react';
-import { Fragment, useState } from 'react';
+import { ArrowUpCircle, Hexagon, LayoutGrid, List, RefreshCw } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAgents, useCheckAgent, useCheckAllAgents, useUpdateAgent } from '@/api/hooks/useAgents';
 import { useHistory } from '@/api/hooks/useHistory';
 import { useConfig } from '@/api/hooks/useSettings';
 import { AgentCard } from '@/components/agents/AgentCard';
 import { AgentListRow } from '@/components/agents/AgentListRow';
-import { Badge } from '@/components/ui/badge';
+import { UpdateLogTable } from '@/components/history/UpdateLogTable';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useStore } from '@/store/useStore';
 
 function AgentCardSkeleton() {
@@ -61,16 +41,6 @@ export function Dashboard() {
   const setAgentChecking = useStore((s) => s.setAgentChecking);
   const viewMode = useStore((s) => s.agentViewMode);
   const setViewMode = useStore((s) => s.setAgentViewMode);
-
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-  const toggleRow = (id: number) => {
-    setExpandedRows((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
 
   const onlineCount = agents.filter((a) => a.status === 'online').length;
   const updateCount = agents.reduce(
@@ -268,109 +238,7 @@ export function Dashboard() {
       {/* Activity Feed */}
       <div data-testid="activity-feed">
         <h2 className="text-lg font-semibold mb-3">Recent Activity</h2>
-        <Card>
-          {!history || history.data.length === 0 ? (
-            <CardContent className="py-8 text-center text-muted-foreground text-sm">
-              No recent activity
-            </CardContent>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-8" />
-                  <TableHead>Container</TableHead>
-                  <TableHead className="hidden md:table-cell">Agent</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead className="hidden md:table-cell">Duration</TableHead>
-                  <TableHead className="hidden sm:table-cell">Time</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {history.data.map((entry) => {
-                  const isSuccess = entry.status === 'success';
-                  const isRolledBack = entry.status === 'rolled_back';
-                  const isExpanded = expandedRows.has(entry.id);
-                  const hasDetails = !!(entry.old_digest || entry.new_digest || entry.error);
-                  const truncate = (d: string | null) =>
-                    d && d.length > 12 ? `${d.slice(0, 12)}...` : d;
-                  return (
-                    <Fragment key={entry.id}>
-                      <TableRow
-                        className={hasDetails ? 'cursor-pointer hover:bg-muted/50' : ''}
-                        onClick={() => hasDetails && toggleRow(entry.id)}
-                      >
-                        <TableCell className="w-8 pr-0">
-                          {hasDetails ? (
-                            isExpanded ? (
-                              <ChevronDown size={14} className="text-muted-foreground" />
-                            ) : (
-                              <ChevronRight size={14} className="text-muted-foreground" />
-                            )
-                          ) : isSuccess ? (
-                            <CheckCircle size={14} className="text-success" />
-                          ) : isRolledBack ? (
-                            <RotateCcw size={14} className="text-primary" />
-                          ) : (
-                            <XCircle size={14} className="text-destructive" />
-                          )}
-                        </TableCell>
-                        <TableCell className="font-medium text-sm">
-                          {entry.container_name}
-                        </TableCell>
-                        <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                          {entry.agent_id}
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={
-                              isSuccess ? 'outline' : isRolledBack ? 'outline' : 'destructive'
-                            }
-                            className={`text-[10px] ${isSuccess ? 'border-success/30 text-success' : isRolledBack ? 'border-primary/30 text-primary' : ''}`}
-                          >
-                            {entry.status === 'rolled_back' ? 'rollback' : entry.status}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                          {entry.duration_ms ? `${(entry.duration_ms / 1000).toFixed(1)}s` : '—'}
-                        </TableCell>
-                        <TableCell className="hidden sm:table-cell text-xs text-muted-foreground whitespace-nowrap">
-                          {formatDistanceToNow(entry.created_at, { addSuffix: true })}
-                        </TableCell>
-                      </TableRow>
-                      {isExpanded && hasDetails && (
-                        <TableRow>
-                          <TableCell />
-                          <TableCell colSpan={5} className="bg-muted/30 py-3">
-                            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs font-mono">
-                              {entry.old_digest && (
-                                <>
-                                  <span className="text-muted-foreground">Old digest</span>
-                                  <span className="break-all">{truncate(entry.old_digest)}</span>
-                                </>
-                              )}
-                              {entry.new_digest && (
-                                <>
-                                  <span className="text-muted-foreground">New digest</span>
-                                  <span className="break-all">{truncate(entry.new_digest)}</span>
-                                </>
-                              )}
-                              {entry.error && (
-                                <>
-                                  <span className="text-muted-foreground">Error</span>
-                                  <span className="text-destructive break-all">{entry.error}</span>
-                                </>
-                              )}
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      )}
-                    </Fragment>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          )}
-        </Card>
+        <UpdateLogTable entries={history?.data ?? []} emptyMessage="No recent activity" />
       </div>
     </div>
   );

--- a/ui/src/pages/History.tsx
+++ b/ui/src/pages/History.tsx
@@ -1,57 +1,8 @@
-import { formatDistanceToNow } from 'date-fns';
-import { ChevronDown, ChevronRight, Info } from 'lucide-react';
-import { Fragment, useState } from 'react';
+import { useState } from 'react';
 import { useHistory, useHistoryStats } from '@/api/hooks/useHistory';
-import { DigestBadge } from '@/components/common/DigestBadge';
 import { Pagination } from '@/components/common/Pagination';
-import { DiffBadge, type ImageDiff, ImageDiffView } from '@/components/diff/ImageDiffView';
-import { Badge } from '@/components/ui/badge';
-import { Card } from '@/components/ui/card';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { UpdateLogTable } from '@/components/history/UpdateLogTable';
 import { Input } from '@/components/ui/input';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-
-function ImageVersionLabel({ image, digest }: { image: string | null; digest: string | null }) {
-  if (!image && !digest) return <span className="text-muted-foreground">—</span>;
-
-  // For old records without image tag, extract name from "image@sha256:hash" digest format
-  const label = image ?? (digest?.includes('@sha256:') ? digest.split('@sha256:')[0] : null);
-
-  if (label) {
-    return (
-      <span className="inline-flex items-center gap-1 font-mono text-xs">
-        {label}
-        {digest && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger render={<span />} className="cursor-help inline-flex shrink-0">
-                <Info size={12} className="text-muted-foreground" />
-              </TooltipTrigger>
-              <TooltipContent side="top" className="max-w-none">
-                <span className="font-mono break-all">{digest}</span>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-      </span>
-    );
-  }
-  return <DigestBadge digest={digest} />;
-}
 
 export function HistoryPage() {
   const [agentFilter, setAgentFilter] = useState('');
@@ -66,16 +17,6 @@ export function HistoryPage() {
     offset: page * limit,
   });
   const { data: stats } = useHistoryStats();
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
-
-  const toggleRow = (id: number) => {
-    setExpandedRows((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
 
   return (
     <div className="p-4 sm:p-6 space-y-4 sm:space-y-6">
@@ -117,141 +58,7 @@ export function HistoryPage() {
         </select>
       </div>
 
-      <Card>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-8" />
-              <TableHead className="hidden sm:table-cell">Time</TableHead>
-              <TableHead className="hidden md:table-cell">Agent</TableHead>
-              <TableHead>Container</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead className="hidden md:table-cell">Duration</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {(!history || history.data.length === 0) && (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center text-muted-foreground py-8">
-                  No history entries
-                </TableCell>
-              </TableRow>
-            )}
-            {history?.data.map((entry) => {
-              const isExpanded = expandedRows.has(entry.id);
-              const parsedDiff: ImageDiff | null = entry.diff
-                ? (() => {
-                    try {
-                      return JSON.parse(entry.diff) as ImageDiff;
-                    } catch {
-                      return null;
-                    }
-                  })()
-                : null;
-              const hasDetails = !!(
-                entry.old_digest ||
-                entry.new_digest ||
-                entry.error ||
-                parsedDiff
-              );
-              return (
-                <Fragment key={entry.id}>
-                  <TableRow
-                    className={hasDetails ? 'cursor-pointer hover:bg-muted/50' : ''}
-                    onClick={() => hasDetails && toggleRow(entry.id)}
-                  >
-                    <TableCell className="w-8 pr-0">
-                      {hasDetails &&
-                        (isExpanded ? (
-                          <ChevronDown size={14} className="text-muted-foreground" />
-                        ) : (
-                          <ChevronRight size={14} className="text-muted-foreground" />
-                        ))}
-                    </TableCell>
-                    <TableCell className="hidden sm:table-cell text-sm text-muted-foreground whitespace-nowrap">
-                      {formatDistanceToNow(entry.created_at, { addSuffix: true })}
-                    </TableCell>
-                    <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                      {entry.agent_name ?? entry.agent_id}
-                    </TableCell>
-                    <TableCell className="text-sm">{entry.container_name}</TableCell>
-                    <TableCell>
-                      <Badge
-                        variant={entry.status === 'success' ? 'outline' : 'destructive'}
-                        className={entry.status === 'success' ? 'border-success text-success' : ''}
-                      >
-                        {entry.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="hidden md:table-cell text-sm text-muted-foreground">
-                      {entry.duration_ms ? `${(entry.duration_ms / 1000).toFixed(1)}s` : '—'}
-                    </TableCell>
-                  </TableRow>
-                  {isExpanded && hasDetails && (
-                    <TableRow>
-                      <TableCell />
-                      <TableCell colSpan={5} className="bg-muted/30 py-3">
-                        <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-xs font-mono">
-                          {(entry.old_digest || entry.old_image) && (
-                            <>
-                              <span className="text-muted-foreground">Old version</span>
-                              <ImageVersionLabel
-                                image={entry.old_image ?? null}
-                                digest={entry.old_digest ?? null}
-                              />
-                            </>
-                          )}
-                          {(entry.new_digest || entry.new_image) && (
-                            <>
-                              <span className="text-muted-foreground">New version</span>
-                              <ImageVersionLabel
-                                image={entry.new_image ?? null}
-                                digest={entry.new_digest ?? null}
-                              />
-                            </>
-                          )}
-                          {entry.duration_ms && (
-                            <>
-                              <span className="text-muted-foreground">Duration</span>
-                              <span>{(entry.duration_ms / 1000).toFixed(1)}s</span>
-                            </>
-                          )}
-                          {entry.error && (
-                            <>
-                              <span className="text-muted-foreground">Error</span>
-                              <span className="text-destructive break-all">{entry.error}</span>
-                            </>
-                          )}
-                          {parsedDiff && (
-                            <>
-                              <span className="text-muted-foreground">Image diff</span>
-                              <Dialog>
-                                <DialogTrigger
-                                  render={<button type="button" className="w-fit cursor-pointer" />}
-                                >
-                                  <DiffBadge diff={parsedDiff} />
-                                </DialogTrigger>
-                                <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
-                                  <DialogHeader>
-                                    <DialogTitle>
-                                      Image changes — {entry.container_name}
-                                    </DialogTitle>
-                                  </DialogHeader>
-                                  <ImageDiffView diff={parsedDiff} />
-                                </DialogContent>
-                              </Dialog>
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </Fragment>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </Card>
+      <UpdateLogTable entries={history?.data ?? []} />
 
       {history && (
         <Pagination


### PR DESCRIPTION
Closes #31

## Summary

- New `ui/src/components/history/UpdateLogTable.tsx` — owns `ImageVersionLabel`, `expandedRows` state, expand/collapse, diff dialog
- `Dashboard.tsx` — ~130 lines removed, replaced with `<UpdateLogTable entries={history?.data ?? []} emptyMessage="No recent activity" />`
- `History.tsx` — same table replaced; filters, stats, and pagination unchanged

## Test plan

- [ ] Dashboard Recent Activity: rows expand with Old/New version labels, tooltip on ℹ icon, diff badge clickable
- [ ] History page: identical behaviour, filters and pagination still work
- [ ] Run UI tests: `cd ui && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)