### PR TITLE
feat(phase3): tag pattern editing in container policy dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **Minimum update age** — hold back auto-updates until an available update has been visible for N hours (configurable per agent), avoiding races with newly-broken tags
 - **Blue-green updates** — start new container first, verify health, then stop old (zero-downtime). Automatically falls back to stop-first if port conflicts are detected (e.g. containers with direct port mappings)
 - **Rollback** — roll back to any previous version or pick a specific tag from the registry
-- **Update groups** — label-based dependency ordering (`com.watchwarden.group`, `com.watchwarden.depends_on`)
+- **Update groups** — label-based (`com.watchwarden.group`, `com.watchwarden.depends_on`) or UI-editable: assign group name, priority, and dependencies per container directly from the dashboard
 - **Per-container policies** — label-driven control: `com.watchwarden.policy=auto|notify|manual` per container; editable from the UI without labels
 - **Semver update levels** — restrict how far images can be upgraded (`patch`, `minor`, `major`) per container or globally via Settings; enforced before auto-update
-- **Tag pattern matching** — filter registry tags by regex via `com.watchwarden.tag_pattern` label
+- **Tag pattern matching** — filter registry tags by regex via `com.watchwarden.tag_pattern` label or the UI policy dialog with built-in presets (semver, v-semver, date, numeric)
 - **Pinned version detection** — blocks accidental updates for containers with explicit version tags (e.g. `postgres:16.2-alpine`), while correctly treating floating tags (`alpine`, `lts`, `stable`) as updatable
 - **Config-only change detection** — detects image updates even when only entrypoint/env/labels changed (same manifest digest, different image ID)
 - **Image diff preview** — shows env, port, entrypoint, and volume changes before updating; diff is also persisted in update history so you can review configuration changes post-update
+- **Image tags in history** — update history shows human-readable image references (`postgres:16.2 → postgres:latest`) alongside the digest; old records fall back to digest-only display
 - **Health-based auto-rollback** — rolls back automatically if a container becomes unhealthy after update, respects healthcheck `start_period` for slow-starting containers
 - **Crash-loop detection** — detects and rolls back containers stuck in restart loops (requires 3+ restarts in 60s to avoid false positives)
 - **AutoRemove container support** — safely updates `--rm` containers by handling Docker API 409/404 during removal
@@ -81,6 +82,9 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 
 ### Observability
 - **Prometheus metrics** — `/metrics` endpoint with per-container labeled gauges (`container_info`, `container_has_update`, `container_last_updated_ms`) and aggregate counters for agents, update counts by status
+- **Registry ETag caching** — agent caches OCI v2 tag-list responses with ETag/If-None-Match; 304 Not Modified responses skip JSON parsing entirely, reducing registry bandwidth on repeated checks
+- **Rate-limit backoff** — automatically backs off and retries on 429/503 registry responses, honouring `Retry-After` headers (capped at 60 s) before retrying once
+- **Diagnostics bundle** — downloadable ZIP from Settings → About containing controller info, agent statuses, registry credential summary (passwords redacted), anonymous Docker Hub image list, and recent controller logs
 
 ### Notifications
 - **Telegram, Slack, Webhook, ntfy** — configurable channels with batched, deduplicated messages
@@ -123,7 +127,12 @@ WatchWarden is a modern alternative to [Watchtower](https://github.com/containrr
 | ntfy Notifications | ✅ Dedicated sender | ❌ None |
 | Notification Templates | ✅ Customizable | ❌ Fixed format |
 | Per-container Policies | ✅ Label-driven | ❌ Global only |
-| Tag Pattern Matching | ✅ Regex-based | ❌ None |
+| Tag Pattern Matching | ✅ Regex + UI presets | ❌ None |
+| Update Groups / Dependencies UI | ✅ Edit group, priority, deps in dashboard | ❌ None |
+| Registry ETag Caching | ✅ 304 shortcut, bandwidth-efficient | ❌ Polls every time |
+| Registry Rate-limit Backoff | ✅ 429/503 retry with Retry-After | ❌ None |
+| Diagnostics Bundle | ✅ Downloadable ZIP with logs + registry info | ❌ None |
+| Update History Image Tags | ✅ Shows `image:tag` not just SHA256 | ❌ None |
 | Prometheus Metrics | ✅ /metrics endpoint | ❌ None |
 | Cloud Registry Auth | ✅ ECR/GCR/ACR | ❌ Basic only |
 | API Token Auth | ✅ Scoped tokens with expiration | ❌ None |

--- a/controller/src/api/routes/agents.ts
+++ b/controller/src/api/routes/agents.ts
@@ -445,10 +445,10 @@ const agentsRoutes: FastifyPluginAsync = async (fastify) => {
 
   fastify.patch<{
     Params: { agentId: string; containerId: string };
-    Body: { policy: string | null; update_level: string | null };
+    Body: { policy: string | null; update_level: string | null; tag_pattern?: string | null };
   }>('/api/agents/:agentId/containers/:containerId', async (request, reply) => {
     const { agentId, containerId } = request.params;
-    const { policy, update_level } = request.body;
+    const { policy, update_level, tag_pattern } = request.body;
 
     const agent = await getAgent(agentId);
     if (!agent) return reply.code(404).send({ error: 'Agent not found' });
@@ -465,8 +465,17 @@ const agentsRoutes: FastifyPluginAsync = async (fastify) => {
         error: 'Invalid update_level. Must be one of: all, major, minor, patch',
       });
     }
+    if (tag_pattern !== undefined && tag_pattern !== null) {
+      try {
+        new RegExp(tag_pattern);
+      } catch {
+        return reply
+          .code(400)
+          .send({ error: 'Invalid tag_pattern: not a valid regular expression' });
+      }
+    }
 
-    await updateContainerPolicy(containerId, { policy, update_level });
+    await updateContainerPolicy(containerId, { policy, update_level, tag_pattern });
     return reply.code(200).send({ message: 'Container policy updated' });
   });
 

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -580,10 +580,13 @@ export async function updateContainerDiff(containerId: string, diff: string | nu
 
 export async function updateContainerPolicy(
   containerId: string,
-  data: { policy: string | null; update_level: string | null },
+  data: { policy: string | null; update_level: string | null; tag_pattern?: string | null },
 ): Promise<void> {
   await sql`
-    UPDATE containers SET policy = ${data.policy}, update_level = ${data.update_level}
+    UPDATE containers
+    SET policy = ${data.policy},
+        update_level = ${data.update_level},
+        tag_pattern = ${data.tag_pattern !== undefined ? data.tag_pattern : sql`tag_pattern`}
     WHERE id = ${containerId} OR docker_id = ${containerId}
   `;
 }

--- a/ui/src/api/hooks/useAgents.ts
+++ b/ui/src/api/hooks/useAgents.ts
@@ -192,15 +192,17 @@ export function useUpdateContainerPolicy() {
       containerId,
       policy,
       updateLevel,
+      tagPattern,
     }: {
       agentId: string;
       containerId: string;
       policy: string | null;
       updateLevel: string | null;
+      tagPattern?: string | null;
     }) =>
       apiRequest<void>(`/agents/${agentId}/containers/${containerId}`, {
         method: 'PATCH',
-        body: JSON.stringify({ policy, update_level: updateLevel }),
+        body: JSON.stringify({ policy, update_level: updateLevel, tag_pattern: tagPattern }),
       }),
     onSuccess: (_, { agentId }) => {
       queryClient.invalidateQueries({ queryKey: ['agents'] });

--- a/ui/src/components/agents/ContainerRow.tsx
+++ b/ui/src/components/agents/ContainerRow.tsx
@@ -88,6 +88,7 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
   const [policyOpen, setPolicyOpen] = useState(false);
   const [editPolicy, setEditPolicy] = useState<string>(container.policy ?? 'auto');
   const [editLevel, setEditLevel] = useState<string>(container.update_level ?? '');
+  const [editTagPattern, setEditTagPattern] = useState<string>(container.tag_pattern ?? '');
   const [pendingAction, setPendingAction] = useState<'start' | 'stop' | 'delete' | 'check' | null>(
     null,
   );
@@ -255,6 +256,7 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
               if (open) {
                 setEditPolicy(container.policy ?? 'auto');
                 setEditLevel(container.update_level ?? '');
+                setEditTagPattern(container.tag_pattern ?? '');
               }
             }}
           >
@@ -363,6 +365,52 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
                     Only applies to semver-tagged images (e.g. 1.2.3).
                   </p>
                 </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="edit-tag-pattern">Tag pattern</Label>
+                  <div className="flex flex-wrap gap-1 mb-1">
+                    {[
+                      { label: 'semver', value: '^\\d+\\.\\d+\\.\\d+$' },
+                      { label: 'v-semver', value: '^v\\d+\\.\\d+\\.\\d+$' },
+                      { label: 'date', value: '^\\d{4}\\.\\d{2}\\.\\d{2}$' },
+                      { label: 'numeric', value: '^\\d+$' },
+                    ].map((preset) => (
+                      <button
+                        key={preset.label}
+                        type="button"
+                        onClick={() => setEditTagPattern(preset.value)}
+                        className={`text-[10px] px-2 py-0.5 rounded border transition-colors cursor-pointer ${
+                          editTagPattern === preset.value
+                            ? 'bg-primary/10 border-primary/40 text-primary'
+                            : 'border-border text-muted-foreground hover:border-primary/30'
+                        }`}
+                      >
+                        {preset.label}
+                      </button>
+                    ))}
+                    {editTagPattern && (
+                      <button
+                        type="button"
+                        onClick={() => setEditTagPattern('')}
+                        className="text-[10px] px-2 py-0.5 rounded border border-border text-muted-foreground hover:border-destructive/40 hover:text-destructive transition-colors cursor-pointer"
+                      >
+                        clear
+                      </button>
+                    )}
+                  </div>
+                  <input
+                    id="edit-tag-pattern"
+                    type="text"
+                    value={editTagPattern}
+                    onChange={(e) => setEditTagPattern(e.target.value)}
+                    placeholder="Regex, e.g. ^\d+\.\d+\.\d+$"
+                    disabled={editPolicy === 'manual'}
+                    className="w-full px-3 py-2 rounded-md bg-card border border-border text-sm font-mono text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Filter which tags are considered for updates. Leave empty to allow any tag.
+                  </p>
+                </div>
               </div>
 
               <DialogFooter>
@@ -376,6 +424,7 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
                         containerId: container.id,
                         policy: editPolicy === 'auto' ? null : editPolicy,
                         updateLevel: editLevel || null,
+                        tagPattern: editTagPattern || null,
                       },
                       {
                         onSuccess: () => setPolicyOpen(false),


### PR DESCRIPTION
## Summary

Extends the per-container policy dialog to allow editing `tag_pattern` alongside `policy` and `update_level`.

- `PATCH /api/agents/:id/containers/:id` now accepts `tag_pattern` (validated as a valid regex before persisting)
- `updateContainerPolicy()` preserves `tag_pattern` when not explicitly passed (no unintended clears)
- `useUpdateContainerPolicy` hook passes `tagPattern` to the API
- ContainerRow policy dialog gets a **Tag pattern** section with four preset chips (`semver`, `v-semver`, `date`, `numeric`) + free-form regex input + clear button

## Test plan

- [ ] Open policy dialog for a container, select `semver` preset — badge shows `TAG` with correct tooltip
- [ ] Save, trigger a heartbeat — pattern survives (COALESCE already in place)
- [ ] Set invalid regex (`[broken`) — API returns 400
- [ ] Run controller tests: `cd controller && npm test`
- [ ] Run UI tests: `cd ui && npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)