### PR TITLE
fix(agent): replace self-update with rename-based blue-green

### DIFF
--- a/agent/managed.go
+++ b/agent/managed.go
@@ -201,18 +201,14 @@ func runManagedMode(cfg *AgentConfig, credStore *CredStore, dockerClient *Docker
 			}()
 		}
 
-		// Self-update: the agent will die during this operation.
-		// Docker's restart policy will bring it back with the new image.
+		// Self-update: use SelfUpdate which renames self, starts the new
+		// container, then force-removes the old one. This avoids the
+		// restart-policy trap where ContainerStop marks the container as
+		// "manually stopped" and unless-stopped never restarts it.
 		if selfID != "" {
-			log.Printf("[handler] self-update: updating own container %s (agent will restart)", selfID[:12])
-			var result *UpdateResult
-			var updateErr error
-			if cmd.Strategy == "start-first" {
-				result, updateErr = updater.BlueGreenUpdate(ctx, selfID)
-			} else {
-				result, updateErr = updater.UpdateContainer(ctx, selfID)
-			}
-			// If we get here, the update failed (process should have been killed on success)
+			log.Printf("[handler] self-update: replacing own container %s", selfID[:12])
+			result, updateErr := updater.SelfUpdate(ctx, selfID)
+			// If we reach here, SelfUpdate failed before the force-remove.
 			if result == nil && updateErr != nil {
 				result = &UpdateResult{
 					ContainerID: selfID,

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -65,6 +65,110 @@ func (u *Updater) IsSelfContainer(containerID string) bool {
 	return containerID == u.selfContainerID || strings.HasPrefix(u.selfContainerID, containerID)
 }
 
+// SelfUpdate replaces the agent's own container with a new image using a
+// rename-based approach that avoids the restart-policy trap:
+//
+//  1. Pull new image
+//  2. Rename self: <name> → <name>-ww-old  (frees the original name)
+//  3. Create + start new container as <name> with new image
+//  4. Force-remove self — Docker sends SIGKILL and removes the container
+//     atomically. A force-removed container is not "manually stopped", so
+//     no restart policy applies and no leftover container exists.
+//
+// The process does not survive step 4. The new container is already running
+// before we die, so there is no downtime gap.
+func (u *Updater) SelfUpdate(ctx context.Context, containerID string) (*UpdateResult, error) {
+	start := time.Now()
+
+	resolvedID, err := u.docker.ResolveContainerID(ctx, containerID)
+	if err == nil {
+		containerID = resolvedID
+	}
+
+	snapshot, err := u.docker.InspectContainer(ctx, containerID)
+	if err != nil {
+		return &UpdateResult{
+			ContainerID: containerID,
+			Success:     false,
+			Error:       fmt.Sprintf("inspect: %v", err),
+			DurationMs:  time.Since(start).Milliseconds(),
+		}, err
+	}
+
+	// Save snapshot before any mutation so rollback is possible if something fails.
+	u.mu.Lock()
+	u.snapshots[containerID] = snapshot
+	u.snapshots[snapshot.Name] = snapshot
+	u.mu.Unlock()
+	saveSnapshot(containerID, snapshot)
+
+	imageRef := resolveCheckRef(ctx, u.docker, snapshot)
+	u.emitProgress(containerID, snapshot.Name, "pulling", "")
+	newDigest, err := u.docker.PullImage(ctx, imageRef)
+	if err != nil {
+		return &UpdateResult{
+			ContainerID:   containerID,
+			ContainerName: snapshot.Name,
+			Success:       false,
+			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
+			Error:         fmt.Sprintf("pull: %v", err),
+			DurationMs:    time.Since(start).Milliseconds(),
+		}, err
+	}
+
+	canonicalName := strings.TrimPrefix(snapshot.Name, "/")
+	tempName := canonicalName + "-ww-old"
+
+	// Step 2: rename self to free the original name.
+	u.emitProgress(containerID, canonicalName, "stopping", "")
+	if err := u.docker.ContainerRename(ctx, containerID, tempName); err != nil {
+		return &UpdateResult{
+			ContainerID:   containerID,
+			ContainerName: canonicalName,
+			Success:       false,
+			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
+			Error:         fmt.Sprintf("rename self: %v", err),
+			DurationMs:    time.Since(start).Milliseconds(),
+		}, err
+	}
+
+	// Step 3: create + start new container with original name and new image.
+	u.emitProgress(containerID, canonicalName, "starting", "")
+	_, err = u.docker.RecreateContainerNamed(ctx, snapshot, imageRef, canonicalName)
+	if err != nil {
+		// Rollback: restore our own name so we keep running.
+		_ = u.docker.ContainerRename(ctx, containerID, canonicalName)
+		return &UpdateResult{
+			ContainerID:   containerID,
+			ContainerName: canonicalName,
+			Success:       false,
+			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
+			Error:         fmt.Sprintf("start new container: %v", err),
+			DurationMs:    time.Since(start).Milliseconds(),
+		}, err
+	}
+
+	// Step 4: force-remove self. Docker sends SIGKILL and removes the container
+	// atomically — the process will not return from this call.
+	log.Printf("[self-update] new %s started; force-removing self (%s)", canonicalName, tempName)
+	_ = u.docker.cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
+
+	// Unreachable: the force-remove killed us.
+	return &UpdateResult{
+		ContainerID:   containerID,
+		ContainerName: canonicalName,
+		Success:       true,
+		OldDigest:     snapshot.ImageDigest,
+		NewDigest:     newDigest,
+		OldImage:      snapshot.ImageRef,
+		NewImage:      imageRef,
+		DurationMs:    time.Since(start).Milliseconds(),
+	}, nil
+}
+
 // StartLockCleanup periodically removes idle per-container lock entries.
 // Runs until ctx is cancelled. Call from main after creating the Updater.
 func (u *Updater) StartLockCleanup(ctx context.Context) {


### PR DESCRIPTION
The previous approach called ContainerStop on the agent's own container, which sent SIGTERM and exited the process. Docker marked the container as "manually stopped", so restart: unless-stopped never restarted it, and the agent stayed dead permanently.

New SelfUpdate method:
1. Pull new image
2. Rename self: <name> → <name>-ww-old  (frees the original name)
3. Create + start new container as <name> with the new image
4. Force-remove self (docker rm -f) — Docker sends SIGKILL and removes the container atomically; no "manually stopped" state, no leftover

The new container is running before step 4, so there is no gap. The force-remove in step 4 is a one-way door: the process does not survive it.