### PR TITLE
fix(check): surface pull failures instead of silently reporting all-clear

### DIFF
--- a/agent/interfaces.go
+++ b/agent/interfaces.go
@@ -66,6 +66,9 @@ type CheckResult struct {
 	LatestDigest  string     `json:"latestDigest"`
 	HasUpdate     bool       `json:"hasUpdate"`
 	Diff          *ImageDiff `json:"diff,omitempty"`
+	// CheckError is set when the check itself failed (e.g. network/pull error).
+	// HasUpdate will be false and digests empty when this is non-empty.
+	CheckError string `json:"checkError,omitempty"`
 }
 
 // UpdateResult represents the result of updating a container.

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -418,7 +418,7 @@ func resolveCheckRef(ctx context.Context, docker *DockerClient, snapshot *Contai
 // SCALE-03: releases the lock before docker pull — the registry read is idempotent
 // and does not need to hold the mutex for potentially minutes.
 func (u *Updater) CheckForUpdates(ctx context.Context, containerIDs []string) ([]CheckResult, error) {
-	var results []CheckResult
+	results := make([]CheckResult, 0)
 
 	for _, id := range containerIDs {
 		// Pre-inspect (no lock) to get the canonical container name for the lock key.
@@ -499,6 +499,12 @@ func (u *Updater) CheckForUpdates(ctx context.Context, containerIDs []string) ([
 			newDigest, pullErr = u.docker.PullImage(ctx, pullRef)
 			if pullErr != nil {
 				log.Printf("[check] %s: pull failed for %s: %v", snapshot.Name, snapshot.ImageRef, pullErr)
+				results = append(results, CheckResult{
+					ContainerID:   id,
+					ContainerName: snapshot.Name,
+					CurrentDigest: snapshot.ImageDigest,
+					CheckError:    fmt.Sprintf("pull failed: %v", pullErr),
+				})
 				continue
 			}
 

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -60,6 +60,8 @@ interface CheckResultItem {
   currentDigest?: string;
   latestDigest?: string | null;
   diff?: Record<string, unknown>;
+  /** Non-empty when the check itself failed (e.g. pull/network error). */
+  checkError?: string;
 }
 
 interface UpdateResultItem {
@@ -289,17 +291,24 @@ export class AgentHub {
 
             case 'CHECK_RESULT': {
               const payload = message.payload as {
-                results: CheckResultItem[];
+                results: CheckResultItem[] | null;
               };
-              const updatesFound = payload.results.filter((r) => r.hasUpdate).length;
+              // Guard: agent sends null (not []) when every pull fails because a Go nil
+              // slice marshals to JSON null. Treat null the same as an empty result set
+              // so CHECK_COMPLETE is still broadcast and the UI spinner clears.
+              const checkItems: CheckResultItem[] = payload.results ?? [];
+              const updatesFound = checkItems.filter((r) => r.hasUpdate).length;
               log.debug(
                 'hub',
-                `CHECK_RESULT from ${agentId}: ${payload.results.length} results, ${updatesFound} updates`,
+                `CHECK_RESULT from ${agentId}: ${checkItems.length} results, ${updatesFound} updates`,
               );
               // Fetch current container state before the loop so we can detect
               // has_update flips for update_first_seen stamping.
               const agentContainersPre = await getContainersByAgent(agentId);
-              for (const r of payload.results) {
+              for (const r of checkItems) {
+                // Skip digest/diff updates for results where the check itself failed
+                // (pull error, network issue). We have no new digest data to store.
+                if (r.checkError) continue;
                 const existing = agentContainersPre.find(
                   (c) => c.docker_id === r.containerId || c.id === r.containerId,
                 );
@@ -323,12 +332,14 @@ export class AgentHub {
                 }
               }
               await updateAgentStatus(agentId, 'online', Date.now());
-              const updatesAvailable = payload.results.filter((r) => r.hasUpdate).length;
+              const updatesAvailable = checkItems.filter((r) => r.hasUpdate).length;
+              const failedChecks = checkItems.filter((r) => r.checkError).length;
               this.broadcaster?.broadcast({
                 type: 'CHECK_COMPLETE',
                 agentId,
                 updatesAvailable,
-                results: payload.results,
+                failedChecks,
+                results: checkItems,
               });
               // DB-02: single DB read for auto-update decision; notification and
               // auto-update paths are mutually exclusive from this point forward.
@@ -358,7 +369,7 @@ export class AgentHub {
                 const agentContainersForUpdate = await getContainersByAgent(agentId);
                 const policy = await getEffectivePolicy(agentId);
                 const globalUpdateLevel = (await getConfig('global_update_level')) ?? '';
-                const containerIds = payload.results
+                const containerIds = checkItems
                   .filter((r) => {
                     if (!r.hasUpdate) return false;
                     const dbContainer = agentContainersForUpdate.find(
@@ -428,7 +439,7 @@ export class AgentHub {
               } else if (updatesAvailable > 0) {
                 // Notification path: auto-update is OFF, notify the operator.
                 const agentContainers = agentContainersPre;
-                const withUpdates = payload.results
+                const withUpdates = checkItems
                   .filter((r) => r.hasUpdate)
                   .map((r) => {
                     const dbContainer = agentContainers.find(

--- a/ui/src/store/useStore.ts
+++ b/ui/src/store/useStore.ts
@@ -164,8 +164,21 @@ export const useStore = create<WatchWardenState>((set, get) => ({
 
     if (type === 'CHECK_COMPLETE' && agentId) {
       get().setAgentChecking(agentId, false);
-      const updatesAvailable = event.updatesAvailable as number;
-      if (updatesAvailable > 0) {
+      const updatesAvailable = (event.updatesAvailable as number) ?? 0;
+      const failedChecks = (event.failedChecks as number) ?? 0;
+      if (failedChecks > 0 && updatesAvailable === 0) {
+        // Every reachable container failed — likely a network/DNS outage.
+        get().addToast({
+          type: 'error',
+          message: `Check incomplete: ${failedChecks} container(s) could not be reached`,
+        });
+      } else if (failedChecks > 0) {
+        // Mixed: some succeeded and found updates, some failed.
+        get().addToast({
+          type: 'info',
+          message: `Check complete: ${updatesAvailable} update(s) available, ${failedChecks} check(s) failed`,
+        });
+      } else if (updatesAvailable > 0) {
         get().addToast({
           type: 'info',
           message: `Check complete: ${updatesAvailable} update(s) available`,


### PR DESCRIPTION
Fixes #43

## What broke

When every image pull fails during a check (e.g. DNS/network outage), the agent's `var results []CheckResult` stayed `nil`. A nil Go slice marshals to JSON **`null`**, not `[]`. The controller's `CHECK_RESULT` handler then called `.filter()` on `null` → `TypeError` → caught silently → `CHECK_COMPLETE` never broadcast → **UI spinner stuck forever**, and once it was manually dismissed the toast said **"all containers up to date"**.

## Changes

### Agent (`agent/interfaces.go`, `agent/updater.go`)
- `CheckForUpdates` now initialises `results` with `make([]CheckResult, 0)` — always marshals to `[]`, never `null`
- Pull failures no longer `continue` silently; each failed container is appended to results with `CheckError` set so the controller and UI know exactly what was unreachable and why

### Controller (`controller/src/ws/hub.ts`)
- Added `checkError?: string` to `CheckResultItem` interface
- Added `??  []` null-guard on `payload.results` as defence-in-depth for old agents
- The digest/diff update loop skips results where `checkError` is set (no new digest data to store)
- `failedChecks` count added to the `CHECK_COMPLETE` broadcast payload

### UI (`ui/src/store/useStore.ts`)
Four distinct toast outcomes on `CHECK_COMPLETE`:

| Situation | Toast |
|-----------|-------|
| All checks failed | ❌ `Check incomplete: N container(s) could not be reached` |
| Mixed (some failed, some have updates) | ℹ️ `Check complete: N update(s) available, M check(s) failed` |
| Updates found, no failures | ℹ️ `Check complete: N update(s) available` |
| All checked, up to date | ✅ `Check complete: all containers up to date` |

## Test plan

- [ ] Run `cd agent && go vet ./... && go test ./...` — all pass
- [ ] Run `cd controller && npm run lint && npm test` — all pass
- [ ] Disconnect network on Docker host → trigger Check All → spinner clears, error toast appears
- [ ] Reconnect network → trigger Check All → correct update/up-to-date toast appears