### PR TITLE
fix(agent): harden self-update with health check, cleanup, and orphan recovery

### DIFF
--- a/agent/docker.go
+++ b/agent/docker.go
@@ -483,6 +483,8 @@ func (d *DockerClient) recreateContainerWithName(ctx context.Context, snapshot *
 
 	// Start the container
 	if err := d.cli.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		// Clean up the created-but-not-started container so the name is freed.
+		_ = d.cli.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		return "", fmt.Errorf("failed to start container: %w", err)
 	}
 

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -136,10 +136,14 @@ func (u *Updater) SelfUpdate(ctx context.Context, containerID string) (*UpdateRe
 
 	// Step 3: create + start new container with original name and new image.
 	u.emitProgress(containerID, canonicalName, "starting", "")
-	_, err = u.docker.RecreateContainerNamed(ctx, snapshot, imageRef, canonicalName)
+	newID, err := u.docker.RecreateContainerNamed(ctx, snapshot, imageRef, canonicalName)
 	if err != nil {
 		// Rollback: restore our own name so we keep running.
-		_ = u.docker.ContainerRename(ctx, containerID, canonicalName)
+		if renameErr := u.docker.ContainerRename(ctx, containerID, canonicalName); renameErr != nil {
+			log.Printf("[self-update] rollback rename failed: %v — container running as %s", renameErr, tempName)
+		} else {
+			log.Printf("[self-update] rolled back: restored name %s", canonicalName)
+		}
 		return &UpdateResult{
 			ContainerID:   containerID,
 			ContainerName: canonicalName,
@@ -150,10 +154,42 @@ func (u *Updater) SelfUpdate(ctx context.Context, containerID string) (*UpdateRe
 			DurationMs:    time.Since(start).Milliseconds(),
 		}, err
 	}
+	log.Printf("[self-update] new container %s (%s) started", canonicalName, newID)
+
+	// Step 3b: verify the new container is actually running before removing ourselves.
+	// Without this check a container that immediately exits (e.g. bad config) would
+	// kill us and leave the service down.
+	time.Sleep(2 * time.Second)
+	info, inspectErr := u.docker.cli.ContainerInspect(ctx, newID)
+	if inspectErr != nil || !info.State.Running {
+		reason := "container not running after start"
+		if inspectErr != nil {
+			reason = fmt.Sprintf("inspect error: %v", inspectErr)
+		} else if info.State != nil {
+			reason = fmt.Sprintf("state=%s exitCode=%d", info.State.Status, info.State.ExitCode)
+		}
+		log.Printf("[self-update] health check failed for new %s: %s — rolling back", canonicalName, reason)
+		// Remove the unhealthy new container so the name is freed.
+		_ = u.docker.cli.ContainerRemove(ctx, newID, container.RemoveOptions{Force: true})
+		if renameErr := u.docker.ContainerRename(ctx, containerID, canonicalName); renameErr != nil {
+			log.Printf("[self-update] rollback rename failed: %v — container running as %s", renameErr, tempName)
+		} else {
+			log.Printf("[self-update] rolled back: restored name %s", canonicalName)
+		}
+		return &UpdateResult{
+			ContainerID:   containerID,
+			ContainerName: canonicalName,
+			Success:       false,
+			OldDigest:     snapshot.ImageDigest,
+			OldImage:      snapshot.ImageRef,
+			Error:         fmt.Sprintf("new container health check failed: %s", reason),
+			DurationMs:    time.Since(start).Milliseconds(),
+		}, fmt.Errorf("new container health check failed: %s", reason)
+	}
 
 	// Step 4: force-remove self. Docker sends SIGKILL and removes the container
 	// atomically — the process will not return from this call.
-	log.Printf("[self-update] new %s started; force-removing self (%s)", canonicalName, tempName)
+	log.Printf("[self-update] new %s healthy; force-removing self (%s)", canonicalName, tempName)
 	_ = u.docker.cli.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true})
 
 	// Unreachable: the force-remove killed us.
@@ -229,7 +265,7 @@ func (u *Updater) RecoverOrphans(ctx context.Context) {
 		}
 	}
 
-	// BUG-03: first pass — detect and resolve orphaned blue-green containers.
+	// First pass — detect and resolve orphaned blue-green containers (-ww-new suffix).
 	// If "nginx-ww-new" exists but "nginx" does not, rename -ww-new to complete
 	// the interrupted blue-green transition.
 	const blueGreenSuffix = "-ww-new"
@@ -253,6 +289,39 @@ func (u *Updater) RecoverOrphans(ctx context.Context) {
 		} else {
 			log.Printf("[recovery] Successfully completed blue-green recovery for %s", originalName)
 			existingNames[originalName] = true // mark as recovered for second pass
+		}
+	}
+
+	// First pass (part 2) — detect and resolve orphaned self-update containers (-ww-old suffix).
+	// These are left behind when a self-update fails after renaming the original container
+	// but before force-removing it. The new container now runs under the original name.
+	const selfUpdateSuffix = "-ww-old"
+	for name, id := range nameToID {
+		if !strings.HasSuffix(name, selfUpdateSuffix) {
+			continue
+		}
+		originalName := strings.TrimSuffix(name, selfUpdateSuffix)
+		if existingNames[originalName] {
+			// New container runs under original name — safe to remove the old one.
+			log.Printf("[recovery] Removing orphaned self-update container %s (new %s is running)", name, originalName)
+			timeout := 10
+			_ = u.docker.cli.ContainerStop(ctx, id, container.StopOptions{Timeout: &timeout})
+			_ = u.docker.cli.ContainerRemove(ctx, id, container.RemoveOptions{})
+		} else {
+			// Original name missing — self-update failed before new container started;
+			// rename old container back so the service is restored.
+			log.Printf("[recovery] Self-update failed: renaming %s → %s to restore service", name, originalName)
+			if err := u.docker.ContainerRename(ctx, id, originalName); err != nil {
+				log.Printf("[recovery] Failed to rename %s → %s: %v", name, originalName, err)
+			} else {
+				// Restart in case it was stopped as part of the failed update.
+				if err := u.docker.cli.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+					log.Printf("[recovery] Failed to restart restored container %s: %v", originalName, err)
+				} else {
+					log.Printf("[recovery] Successfully restored %s from self-update orphan", originalName)
+				}
+				existingNames[originalName] = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #45

## Summary

Three bugs caused the self-updating agent container to stop and never restart:

- **`recreateContainerWithName`**: `ContainerStart` failure left an orphaned stopped container holding the original name, causing the rollback rename to silently fail
- **`SelfUpdate`**: no health verification between starting the new container and force-removing the old one — an immediately-exiting container would kill the agent with no fallback
- **`RecoverOrphans`**: only handled `-ww-new` blue-green orphans; `-ww-old` self-update orphans were ignored on next startup

## Changes

### `agent/docker.go`
- Force-remove the created-but-not-started container when `ContainerStart` fails, freeing the name for rollback rename

### `agent/updater.go` — `SelfUpdate`
- Capture new container ID from `RecreateContainerNamed`
- Wait 2 seconds then inspect new container state before removing old one
- If not running: remove failed container, rename old container back to original name, return error
- Log rollback outcomes explicitly so failures are visible in logs

### `agent/updater.go` — `RecoverOrphans`
- Detect `*-ww-old` containers on startup
- If original name exists (new container running): remove the orphan
- If original name missing (self-update failed before new container started): rename `*-ww-old` → original name and restart it to restore service

## Test plan

- [ ] All existing agent tests pass (`go test ./...` — 160 passed)
- [ ] Manually verify: trigger self-update, observe `[self-update] new <name> healthy; force-removing self` in logs
- [ ] Simulate ContainerStart failure (e.g. port conflict): verify rollback rename succeeds and agent continues running under original name
- [ ] Simulate new container immediately exiting: verify health check catches it and rolls back
- [ ] Restart agent after leaving a `*-ww-old` container: verify RecoverOrphans restores service

🤖 Generated with [Claude Code](https://claude.com/claude-code)