### PR TITLE
fix(agent): prevent concurrent self-updates; remove agent port binding

### DIFF
--- a/agent/updater.go
+++ b/agent/updater.go
@@ -38,6 +38,9 @@ type Updater struct {
 	// When non-empty, self-updates are deferred to run last and the agent
 	// expects to be killed mid-operation (Docker restart policy brings it back).
 	selfContainerID string
+	// selfUpdateMu prevents concurrent self-update calls (e.g. two rapid UPDATE
+	// messages from the controller) that would both try to rename the same container.
+	selfUpdateMu sync.Mutex
 }
 
 // NewUpdater creates an Updater with the given Docker client.
@@ -78,6 +81,11 @@ func (u *Updater) IsSelfContainer(containerID string) bool {
 // The process does not survive step 4. The new container is already running
 // before we die, so there is no downtime gap.
 func (u *Updater) SelfUpdate(ctx context.Context, containerID string) (*UpdateResult, error) {
+	// Prevent two concurrent self-updates (e.g. rapid UPDATE messages) from
+	// both renaming the same container and leaving an unrecoverable orphan.
+	u.selfUpdateMu.Lock()
+	defer u.selfUpdateMu.Unlock()
+
 	start := time.Now()
 
 	resolvedID, err := u.docker.ResolveContainerID(ctx, containerID)
@@ -138,6 +146,10 @@ func (u *Updater) SelfUpdate(ctx context.Context, containerID string) (*UpdateRe
 	u.emitProgress(containerID, canonicalName, "starting", "")
 	newID, err := u.docker.RecreateContainerNamed(ctx, snapshot, imageRef, canonicalName)
 	if err != nil {
+		log.Printf("[self-update] failed to start new %s: %v — rolling back", canonicalName, err)
+		if strings.Contains(err.Error(), "port is already allocated") || strings.Contains(err.Error(), "address already in use") {
+			log.Printf("[self-update] hint: agent has exposed ports that are still held by the running container; remove port bindings from the agent service to enable self-update")
+		}
 		// Rollback: restore our own name so we keep running.
 		if renameErr := u.docker.ContainerRename(ctx, containerID, canonicalName); renameErr != nil {
 			log.Printf("[self-update] rollback rename failed: %v — container running as %s", renameErr, tempName)

--- a/controller/src/scheduler/__tests__/engine.test.ts
+++ b/controller/src/scheduler/__tests__/engine.test.ts
@@ -143,6 +143,10 @@ describe('Scheduler', () => {
   });
 
   it('L2: does NOT run catch-up when check_on_startup is unset', async () => {
+    // Use a non-firing schedule so the regular cron doesn't send a CHECK during
+    // the 1500ms wait and produce a false positive (the test only cares about
+    // whether the catch-up path fires, not the normal scheduled path).
+    await setConfig('global_schedule', '0 4 * * *');
     // Set scheduler_last_run to 48h ago — stale enough for catch-up
     await setConfig('scheduler_last_run', String(Date.now() - 48 * 60 * 60 * 1000));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,9 @@ services:
     build: ./agent
     container_name: watchwarden-agent-local
     restart: unless-stopped
-    ports:
-      - "9090:8080"
+    # Agent port not exposed — the agent communicates outbound to the controller
+    # via WebSocket and needs no inbound port. Exposing it would block self-update
+    # (the running container holds the host port, preventing the new container from starting).
     volumes:
       - ${DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
       - agent_snapshots:/var/lib/watchwarden/snapshots


### PR DESCRIPTION
## Changes

**Concurrent self-update race**

Two rapid UPDATE messages from the controller could both enter `SelfUpdate` concurrently — each trying to rename the same container — producing duplicate "rolled back" log lines and leaving an orphaned `-ww-old` container. Adds `selfUpdateMu sync.Mutex` to serialize all self-update calls.

**Port-conflict error clarity**

When `RecreateContainerNamed` fails, the failure reason was only visible in the returned `UpdateResult`, not in the logs before the "rolled back" line. Now logs the actual error first, and if it's a port conflict, prints a specific hint explaining why it happens and how to fix it.

**Remove agent port binding from dev compose**

`docker-compose.yml` exposed the agent on `9090:8080`. The agent only needs an outbound WebSocket connection to the controller — no inbound port is required. Exposing one prevents self-update: the running container holds the host port, so the new container can't start. Removed and replaced with an explanatory comment.

The production compose already has no port binding on the agent.

## Test plan

- [ ] Trigger self-update twice in rapid succession — verify only one proceeds, second is serialized (not a duplicate rename)
- [ ] Self-update with no exposed ports: verify clean `[self-update] new container ... started` log
- [ ] `docker compose up` with updated compose: verify agent starts without port 9090

🤖 Generated with [Claude Code](https://claude.com/claude-code)