### PR TITLE
fix(notify): consolidate per-agent notifications into single batched messages

### DIFF
--- a/controller/src/api/routes/notifications.ts
+++ b/controller/src/api/routes/notifications.ts
@@ -127,10 +127,14 @@ const notificationRoutes: FastifyPluginAsync = async (fastify) => {
           },
           {
             type: 'update_success',
-            agentName: 'test-agent',
-            containers: [
-              { name: 'nginx', image: 'nginx:latest', durationMs: 12000 },
-              { name: 'redis', image: 'redis:alpine', durationMs: 8000 },
+            agents: [
+              {
+                agentName: 'test-agent',
+                containers: [
+                  { name: 'nginx', image: 'nginx:latest', durationMs: 12000 },
+                  { name: 'redis', image: 'redis:alpine', durationMs: 8000 },
+                ],
+              },
             ],
           },
         );

--- a/controller/src/notifications/__tests__/notifier.test.ts
+++ b/controller/src/notifications/__tests__/notifier.test.ts
@@ -63,8 +63,12 @@ describe('notifier (Finding 6.2)', () => {
 
     const event: NotificationEvent = {
       type: 'update_success',
-      agentName: 'agent-1',
-      containers: [{ name: 'nginx', image: 'nginx:latest', durationMs: 100 }],
+      agents: [
+        {
+          agentName: 'agent-1',
+          containers: [{ name: 'nginx', image: 'nginx:latest', durationMs: 100 }],
+        },
+      ],
     };
 
     // Re-import notifier to get fresh instance with mocked senders

--- a/controller/src/notifications/__tests__/ntfy.test.ts
+++ b/controller/src/notifications/__tests__/ntfy.test.ts
@@ -2,6 +2,13 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { sendNtfy } from '../senders/ntfy.js';
 import type { NotificationEvent } from '../types.js';
 
+const successEvent: NotificationEvent = {
+  type: 'update_success',
+  agents: [
+    { agentName: 'prod', containers: [{ name: 'app', image: 'app:latest', durationMs: 5000 }] },
+  ],
+};
+
 describe('ntfy sender', () => {
   const originalFetch = globalThis.fetch;
 
@@ -45,14 +52,7 @@ describe('ntfy sender', () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     globalThis.fetch = mockFetch;
 
-    await sendNtfy(
-      { server: 'https://ntfy.example.com', topic: 'alerts' },
-      {
-        type: 'update_success',
-        agentName: 'prod',
-        containers: [{ name: 'app', image: 'app:latest', durationMs: 5000 }],
-      },
-    );
+    await sendNtfy({ server: 'https://ntfy.example.com', topic: 'alerts' }, successEvent);
 
     expect((mockFetch.mock.calls[0] as [string])[0]).toBe('https://ntfy.example.com/alerts');
   });
@@ -61,14 +61,7 @@ describe('ntfy sender', () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     globalThis.fetch = mockFetch;
 
-    await sendNtfy(
-      { topic: 'test', priority: 'high' },
-      {
-        type: 'update_success',
-        agentName: 'local',
-        containers: [{ name: 'app', image: 'app:latest', durationMs: 100 }],
-      },
-    );
+    await sendNtfy({ topic: 'test', priority: 'high' }, successEvent);
 
     const opts = mockFetch.mock.calls[0]?.[1] as {
       headers: Record<string, string>;
@@ -80,14 +73,7 @@ describe('ntfy sender', () => {
     const mockFetch = vi.fn().mockResolvedValue({ ok: true });
     globalThis.fetch = mockFetch;
 
-    await sendNtfy(
-      { topic: 'test', token: 'tk_secret' },
-      {
-        type: 'update_success',
-        agentName: 'local',
-        containers: [{ name: 'app', image: 'app:latest', durationMs: 100 }],
-      },
-    );
+    await sendNtfy({ topic: 'test', token: 'tk_secret' }, successEvent);
 
     const opts = mockFetch.mock.calls[0]?.[1] as {
       headers: Record<string, string>;
@@ -98,15 +84,6 @@ describe('ntfy sender', () => {
   it('throws on non-ok response', async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429 });
 
-    await expect(
-      sendNtfy(
-        { topic: 'test' },
-        {
-          type: 'update_success',
-          agentName: 'local',
-          containers: [{ name: 'app', image: 'app:latest', durationMs: 100 }],
-        },
-      ),
-    ).rejects.toThrow('429');
+    await expect(sendNtfy({ topic: 'test' }, successEvent)).rejects.toThrow('429');
   });
 });

--- a/controller/src/notifications/__tests__/session-batcher.test.ts
+++ b/controller/src/notifications/__tests__/session-batcher.test.ts
@@ -9,6 +9,7 @@ vi.mock('../notifier.js', () => ({
 
 import { notifier } from '../notifier.js';
 import {
+  addUpdateResult,
   clearPendingTimers,
   dispatchCheckResults,
   expectCheckResults,
@@ -34,210 +35,350 @@ describe('session-batcher', () => {
     vi.useRealTimers();
   });
 
-  it('dispatchCheckResults batches results within default 5s window', () => {
-    const u = uid();
+  describe('check result batching', () => {
+    it('batches check results within 90s sliding window', () => {
+      const u = uid();
 
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
 
-    vi.advanceTimersByTime(3_000);
-    expect(notifier.dispatch).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(30_000);
+      expect(notifier.dispatch).not.toHaveBeenCalled();
 
-    dispatchCheckResults(
-      `agent-2-${u}`,
-      [{ name: `redis-${u}`, image: `redis:${u}` }],
-      `agent-2-${u}`,
-    );
+      dispatchCheckResults(
+        `agent-2-${u}`,
+        [{ name: `redis-${u}`, image: `redis:${u}` }],
+        `agent-2-${u}`,
+      );
 
-    // Advance past the 5s window from the first dispatch
-    vi.advanceTimersByTime(5_000);
+      // Advance past the 90s window from the second dispatch
+      vi.advanceTimersByTime(90_000);
 
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-    const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
-    expect(event).toMatchObject({
-      type: 'update_available',
-      agents: expect.arrayContaining([
-        expect.objectContaining({ agentName: `agent-1-${u}` }),
-        expect.objectContaining({ agentName: `agent-2-${u}` }),
-      ]),
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_available',
+        agents: expect.arrayContaining([
+          expect.objectContaining({ agentName: `agent-1-${u}` }),
+          expect.objectContaining({ agentName: `agent-2-${u}` }),
+        ]),
+      });
+    });
+
+    it('expectCheckResults waits for all agents before flushing', () => {
+      const u = uid();
+      expectCheckResults(3);
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+      vi.advanceTimersByTime(3_000);
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      dispatchCheckResults(
+        `agent-2-${u}`,
+        [{ name: `redis-${u}`, image: `redis:${u}` }],
+        `agent-2-${u}`,
+      );
+      vi.advanceTimersByTime(5_000);
+      // Still not flushed — waiting for 3rd agent
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      dispatchCheckResults(
+        `agent-3-${u}`,
+        [{ name: `postgres-${u}`, image: `postgres:${u}` }],
+        `agent-3-${u}`,
+      );
+
+      // Should flush immediately after 3rd agent
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_available',
+        agents: expect.arrayContaining([
+          expect.objectContaining({ agentName: `agent-1-${u}` }),
+          expect.objectContaining({ agentName: `agent-2-${u}` }),
+          expect.objectContaining({ agentName: `agent-3-${u}` }),
+        ]),
+      });
+    });
+
+    it('expectCheckResults flushes on 30s timeout if not all agents respond', () => {
+      const u = uid();
+      expectCheckResults(3);
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+      dispatchCheckResults(
+        `agent-2-${u}`,
+        [{ name: `redis-${u}`, image: `redis:${u}` }],
+        `agent-2-${u}`,
+      );
+
+      // Advance past default window — should NOT flush because expecting 3 agents
+      vi.advanceTimersByTime(6_000);
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      // Advance to 30s total — timeout should trigger flush
+      vi.advanceTimersByTime(24_000);
+
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_available',
+        agents: [
+          expect.objectContaining({ agentName: `agent-1-${u}` }),
+          expect.objectContaining({ agentName: `agent-2-${u}` }),
+        ],
+      });
+    });
+
+    it('deduplicates same container within 24 hours', () => {
+      const u = uid();
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+
+      // Flush the first batch
+      vi.advanceTimersByTime(90_000);
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+
+      vi.mocked(notifier.dispatch).mockClear();
+
+      // Dispatch same agent+container again — should be deduped
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+
+      vi.advanceTimersByTime(90_000);
+      // The container was deduplicated, so the batch had 0 new containers — no dispatch.
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates same container even when image changes (rolling :latest)', () => {
+      const u = uid();
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+        `agent-1-${u}`,
+      );
+
+      vi.advanceTimersByTime(90_000);
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+
+      vi.mocked(notifier.dispatch).mockClear();
+
+      // Same container, different image digest / tag — should still be deduped by name
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: 'nginx:latest' }],
+        `agent-1-${u}`,
+      );
+
+      vi.advanceTimersByTime(90_000);
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('counts agents with zero updates toward completion', () => {
+      const u = uid();
+      expectCheckResults(2);
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      // agent-2 has no updates (empty containers array)
+      dispatchCheckResults(`agent-2-${u}`, [], `agent-2-${u}`);
+
+      // Should flush immediately because both agents have reported
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_available',
+        agents: [expect.objectContaining({ agentName: `agent-1-${u}` })],
+      });
+    });
+
+    it('clearPendingTimers flushes check batch and clears timer', () => {
+      const u = uid();
+
+      dispatchCheckResults(
+        `agent-1-${u}`,
+        [{ name: `nginx-${u}`, image: `nginx:${u}` }],
+        `agent-1-${u}`,
+      );
+
+      // Don't wait for timer — clear immediately
+      clearPendingTimers();
+
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_available',
+        agents: [expect.objectContaining({ agentName: `agent-1-${u}` })],
+      });
+
+      // Advancing timers should NOT trigger another flush
+      vi.mocked(notifier.dispatch).mockClear();
+      vi.advanceTimersByTime(90_000);
+      expect(notifier.dispatch).not.toHaveBeenCalled();
     });
   });
 
-  it('expectCheckResults waits for all agents before flushing', () => {
-    const u = uid();
-    expectCheckResults(3);
+  describe('update result batching', () => {
+    it('consolidates update results from multiple agents into one notification', () => {
+      const u = uid();
 
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-    vi.advanceTimersByTime(3_000);
-    expect(notifier.dispatch).not.toHaveBeenCalled();
+      addUpdateResult(`plex-${u}`, {
+        containerId: `c1-${u}`,
+        containerName: `plex-${u}`,
+        image: `plex:latest`,
+        success: true,
+        error: null,
+        durationMs: 5000,
+      });
 
-    dispatchCheckResults(
-      `agent-2-${u}`,
-      [{ name: `redis-${u}`, image: `redis:${u}` }],
-      `agent-2-${u}`,
-    );
-    vi.advanceTimersByTime(5_000);
-    // Still not flushed — waiting for 3rd agent
-    expect(notifier.dispatch).not.toHaveBeenCalled();
+      addUpdateResult(`servarr-${u}`, {
+        containerId: `c2-${u}`,
+        containerName: `radarr-${u}`,
+        image: `radarr:latest`,
+        success: true,
+        error: null,
+        durationMs: 3000,
+      });
 
-    dispatchCheckResults(
-      `agent-3-${u}`,
-      [{ name: `postgres-${u}`, image: `postgres:${u}` }],
-      `agent-3-${u}`,
-    );
+      // Neither should have fired yet
+      expect(notifier.dispatch).not.toHaveBeenCalled();
 
-    // Should flush immediately after 3rd agent
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-    const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
-    expect(event).toMatchObject({
-      type: 'update_available',
-      agents: expect.arrayContaining([
-        expect.objectContaining({ agentName: `agent-1-${u}` }),
-        expect.objectContaining({ agentName: `agent-2-${u}` }),
-        expect.objectContaining({ agentName: `agent-3-${u}` }),
-      ]),
-    });
-  });
+      // Advance past 30s sliding window
+      vi.advanceTimersByTime(30_000);
 
-  it('expectCheckResults flushes on 30s timeout if not all agents respond', () => {
-    const u = uid();
-    expectCheckResults(3);
-
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-    dispatchCheckResults(
-      `agent-2-${u}`,
-      [{ name: `redis-${u}`, image: `redis:${u}` }],
-      `agent-2-${u}`,
-    );
-
-    // Advance past default 5s — should NOT flush because expecting 3 agents
-    vi.advanceTimersByTime(6_000);
-    expect(notifier.dispatch).not.toHaveBeenCalled();
-
-    // Advance to 30s total — timeout should trigger flush
-    vi.advanceTimersByTime(24_000);
-
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-    const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
-    expect(event).toMatchObject({
-      type: 'update_available',
-      agents: [
-        expect.objectContaining({ agentName: `agent-1-${u}` }),
-        expect.objectContaining({ agentName: `agent-2-${u}` }),
-      ],
-    });
-  });
-
-  it('dispatchCheckResults deduplicates same container within 24 hours', () => {
-    const u = uid();
-
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-
-    // Flush the first batch
-    vi.advanceTimersByTime(5_000);
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-
-    vi.mocked(notifier.dispatch).mockClear();
-
-    // Dispatch same agent+container again — should be deduped
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-
-    vi.advanceTimersByTime(5_000);
-    // The container was deduplicated, so the batch had 0 new containers.
-    // flushCheckBatch filters out agents with no containers — no dispatch.
-    expect(notifier.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('dispatchCheckResults deduplicates same container even when image changes (rolling :latest)', () => {
-    const u = uid();
-
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
-      `agent-1-${u}`,
-    );
-
-    vi.advanceTimersByTime(5_000);
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-
-    vi.mocked(notifier.dispatch).mockClear();
-
-    // Same container, different image digest / tag — should still be deduped by name
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: 'nginx:latest' }],
-      `agent-1-${u}`,
-    );
-
-    vi.advanceTimersByTime(5_000);
-    expect(notifier.dispatch).not.toHaveBeenCalled();
-  });
-
-  it('expectCheckResults counts agents with zero updates toward completion', () => {
-    const u = uid();
-    expectCheckResults(2);
-
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-
-    expect(notifier.dispatch).not.toHaveBeenCalled();
-
-    // agent-2 has no updates (empty containers array)
-    dispatchCheckResults(`agent-2-${u}`, [], `agent-2-${u}`);
-
-    // Should flush immediately because both agents have reported
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-    const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
-    expect(event).toMatchObject({
-      type: 'update_available',
-      agents: [expect.objectContaining({ agentName: `agent-1-${u}` })],
-    });
-  });
-
-  it('clearPendingTimers flushes and clears batch', () => {
-    const u = uid();
-
-    dispatchCheckResults(
-      `agent-1-${u}`,
-      [{ name: `nginx-${u}`, image: `nginx:${u}` }],
-      `agent-1-${u}`,
-    );
-
-    // Don't wait for timer — clear immediately
-    clearPendingTimers();
-
-    expect(notifier.dispatch).toHaveBeenCalledTimes(1);
-    const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
-    expect(event).toMatchObject({
-      type: 'update_available',
-      agents: [expect.objectContaining({ agentName: `agent-1-${u}` })],
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_success',
+        agents: expect.arrayContaining([
+          expect.objectContaining({ agentName: `plex-${u}` }),
+          expect.objectContaining({ agentName: `servarr-${u}` }),
+        ]),
+      });
     });
 
-    // Advancing timers should NOT trigger another flush
-    vi.mocked(notifier.dispatch).mockClear();
-    vi.advanceTimersByTime(10_000);
-    expect(notifier.dispatch).not.toHaveBeenCalled();
+    it('separates successes and failures into distinct dispatches', () => {
+      const u = uid();
+
+      addUpdateResult(`agent-a-${u}`, {
+        containerId: `c1-${u}`,
+        containerName: `nginx-${u}`,
+        image: 'nginx:latest',
+        success: true,
+        error: null,
+        durationMs: 2000,
+      });
+
+      addUpdateResult(`agent-b-${u}`, {
+        containerId: `c2-${u}`,
+        containerName: `redis-${u}`,
+        image: 'redis:latest',
+        success: false,
+        error: 'image pull failed',
+        durationMs: 0,
+      });
+
+      vi.advanceTimersByTime(30_000);
+
+      expect(notifier.dispatch).toHaveBeenCalledTimes(2);
+      const calls = vi.mocked(notifier.dispatch).mock.calls.map((c) => c[0]);
+      expect(calls.find((e) => e.type === 'update_success')).toMatchObject({
+        type: 'update_success',
+        agents: [expect.objectContaining({ agentName: `agent-a-${u}` })],
+      });
+      expect(calls.find((e) => e.type === 'update_failed')).toMatchObject({
+        type: 'update_failed',
+        agents: [expect.objectContaining({ agentName: `agent-b-${u}` })],
+      });
+    });
+
+    it('sliding window resets on each new result', () => {
+      const u = uid();
+
+      addUpdateResult(`agent-${u}`, {
+        containerId: `c1-${u}`,
+        containerName: `nginx-${u}`,
+        image: 'nginx:latest',
+        success: true,
+        error: null,
+        durationMs: 1000,
+      });
+
+      vi.advanceTimersByTime(20_000); // within window
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      addUpdateResult(`agent-${u}`, {
+        containerId: `c2-${u}`,
+        containerName: `redis-${u}`,
+        image: 'redis:latest',
+        success: true,
+        error: null,
+        durationMs: 1000,
+      });
+
+      vi.advanceTimersByTime(20_000); // within new window
+      expect(notifier.dispatch).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(10_000); // now past 30s from last result
+
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({
+        type: 'update_success',
+        agents: [
+          expect.objectContaining({
+            agentName: `agent-${u}`,
+            containers: expect.arrayContaining([
+              expect.objectContaining({ name: `nginx-${u}` }),
+              expect.objectContaining({ name: `redis-${u}` }),
+            ]),
+          }),
+        ],
+      });
+    });
+
+    it('clearPendingTimers flushes update batch', () => {
+      const u = uid();
+
+      addUpdateResult(`agent-${u}`, {
+        containerId: `c1-${u}`,
+        containerName: `nginx-${u}`,
+        image: 'nginx:latest',
+        success: true,
+        error: null,
+        durationMs: 1000,
+      });
+
+      clearPendingTimers();
+
+      expect(notifier.dispatch).toHaveBeenCalledTimes(1);
+      const event = vi.mocked(notifier.dispatch).mock.calls[0]?.[0];
+      expect(event).toMatchObject({ type: 'update_success' });
+    });
   });
 });

--- a/controller/src/notifications/__tests__/webhook.test.ts
+++ b/controller/src/notifications/__tests__/webhook.test.ts
@@ -29,8 +29,12 @@ import { sendWebhook } from '../senders/webhook.js';
 
 const testEvent: NotificationEvent = {
   type: 'update_success',
-  agentName: 'test-agent',
-  containers: [{ name: 'nginx', image: 'nginx:latest', durationMs: 500 }],
+  agents: [
+    {
+      agentName: 'test-agent',
+      containers: [{ name: 'nginx', image: 'nginx:latest', durationMs: 500 }],
+    },
+  ],
 };
 
 describe('webhook SSRF protection (SEC-02)', () => {

--- a/controller/src/notifications/senders/ntfy.ts
+++ b/controller/src/notifications/senders/ntfy.ts
@@ -50,12 +50,24 @@ export async function sendNtfy(
 
 function formatTitle(event: NotificationEvent): string {
   switch (event.type) {
-    case 'update_available':
-      return `Updates Available — ${event.agents?.[0]?.agentName ?? 'WatchWarden'}`;
-    case 'update_success':
-      return `Update Succeeded — ${event.agentName ?? 'WatchWarden'}`;
-    case 'update_failed':
-      return `Update Failed — ${event.agentName ?? 'WatchWarden'}`;
+    case 'update_available': {
+      if (event.agents.length === 1) {
+        return `Updates Available — ${event.agents[0]?.agentName ?? 'WatchWarden'}`;
+      }
+      return `Updates Available — ${event.agents.length} agents`;
+    }
+    case 'update_success': {
+      if (event.agents.length === 1) {
+        return `Update Complete — ${event.agents[0]?.agentName ?? 'WatchWarden'}`;
+      }
+      return `Update Complete — ${event.agents.length} agents`;
+    }
+    case 'update_failed': {
+      if (event.agents.length === 1) {
+        return `Update Failed — ${event.agents[0]?.agentName ?? 'WatchWarden'}`;
+      }
+      return `Update Failed — ${event.agents.length} agents`;
+    }
     default:
       return 'WatchWarden Notification';
   }
@@ -75,17 +87,25 @@ function formatBody(event: NotificationEvent, linkTemplate: string | null): stri
     return lines.join('\n') || 'Updates available';
   }
   if (event.type === 'update_success') {
-    return event.containers
-      .map((c) => {
-        let line = `\u2713 ${c.name} (${c.durationMs}ms)`;
+    const lines: string[] = [];
+    for (const agent of event.agents) {
+      for (const c of agent.containers) {
+        let line = `✓ ${c.name} (${Math.round(c.durationMs / 1000)}s)`;
         const link = linkTemplate ? renderImageLink(c.image, linkTemplate) : '';
         if (link) line += `\n  ${link}`;
-        return line;
-      })
-      .join('\n');
+        lines.push(line);
+      }
+    }
+    return lines.join('\n');
   }
   if (event.type === 'update_failed') {
-    return event.containers.map((c) => `\u2717 ${c.name}: ${c.error}`).join('\n');
+    const lines: string[] = [];
+    for (const agent of event.agents) {
+      for (const c of agent.containers) {
+        lines.push(`✗ ${c.name}: ${c.error}`);
+      }
+    }
+    return lines.join('\n');
   }
   return '';
 }

--- a/controller/src/notifications/senders/telegram.ts
+++ b/controller/src/notifications/senders/telegram.ts
@@ -32,13 +32,15 @@ export function formatTelegramMessage(event: NotificationEvent, options?: Format
       vars.agentName = event.agents[0]?.agentName ?? '';
       vars.count = String(names.length);
     } else if (event.type === 'update_success') {
-      vars.agentName = event.agentName;
-      vars.containers = event.containers.map((c) => c.name).join(', ');
-      vars.count = String(event.containers.length);
+      const names = event.agents.flatMap((a) => a.containers.map((c) => c.name));
+      vars.agentName = event.agents[0]?.agentName ?? '';
+      vars.containers = names.join(', ');
+      vars.count = String(names.length);
     } else if (event.type === 'update_failed') {
-      vars.agentName = event.agentName;
-      vars.containers = event.containers.map((c) => c.name).join(', ');
-      vars.count = String(event.containers.length);
+      const names = event.agents.flatMap((a) => a.containers.map((c) => c.name));
+      vars.agentName = event.agents[0]?.agentName ?? '';
+      vars.containers = names.join(', ');
+      vars.count = String(names.length);
     }
     return interpolateTemplate(options.template, vars);
   }
@@ -48,43 +50,63 @@ export function formatTelegramMessage(event: NotificationEvent, options?: Format
   switch (event.type) {
     case 'update_available': {
       if (event.agents.length === 1) {
+        // biome-ignore lint/style/noNonNullAssertion: guarded by length === 1
+        const agent = event.agents[0]!;
+        const items = agent.containers
+          .map((c) => appendLink(`• ${formatContainerName(c.name, c.image)}`, c.image, linkTpl))
+          .join('\n');
+        return `🔔 Updates Available — ${agent.agentName}\n\n${items}`;
+      }
+      const totalContainers = event.agents.reduce((sum, a) => sum + a.containers.length, 0);
+      const sections = event.agents
+        .map((agent) => {
+          const items = agent.containers
+            .map((c) => appendLink(`  • ${formatContainerName(c.name, c.image)}`, c.image, linkTpl))
+            .join('\n');
+          return `📍 ${agent.agentName}\n${items}`;
+        })
+        .join('\n\n');
+      return `🔔 Updates Available — ${event.agents.length} agents, ${totalContainers} containers\n\n${sections}`;
+    }
+    case 'update_success': {
+      if (event.agents.length === 1) {
+        // biome-ignore lint/style/noNonNullAssertion: guarded by length === 1
         const agent = event.agents[0]!;
         const items = agent.containers
           .map((c) =>
-            appendLink(`\u2022 ${formatContainerName(c.name, c.image)}`, c.image, linkTpl),
+            appendLink(`• ${c.name} — ${Math.round(c.durationMs / 1000)}s`, c.image, linkTpl),
           )
           .join('\n');
-        return `\uD83D\uDD14 Updates Available \u2014 ${agent.agentName}\n\n${items}`;
+        return `✅ Update Complete — ${agent.agentName}\n\n${items}`;
       }
-      // Multiple agents
       const totalContainers = event.agents.reduce((sum, a) => sum + a.containers.length, 0);
       const sections = event.agents
         .map((agent) => {
           const items = agent.containers
             .map((c) =>
-              appendLink(`  \u2022 ${formatContainerName(c.name, c.image)}`, c.image, linkTpl),
+              appendLink(`  • ${c.name} — ${Math.round(c.durationMs / 1000)}s`, c.image, linkTpl),
             )
             .join('\n');
-          return `\uD83D\uDCCD ${agent.agentName}\n${items}`;
+          return `📍 ${agent.agentName}\n${items}`;
         })
         .join('\n\n');
-      return `\uD83D\uDD14 Updates Available \u2014 ${event.agents.length} agents, ${totalContainers} containers\n\n${sections}`;
-    }
-    case 'update_success': {
-      const items = event.containers
-        .map((c) =>
-          appendLink(
-            `\u2022 ${c.name} \u2014 ${Math.round(c.durationMs / 1000)}s`,
-            c.image,
-            linkTpl,
-          ),
-        )
-        .join('\n');
-      return `\u2705 Update Complete \u2014 ${event.agentName}\n\n${items}`;
+      return `✅ Update Complete — ${event.agents.length} agents, ${totalContainers} containers\n\n${sections}`;
     }
     case 'update_failed': {
-      const items = event.containers.map((c) => `\u2022 ${c.name} \u2014 ${c.error}`).join('\n');
-      return `\u274C Update Failed \u2014 ${event.agentName}\n\n${items}`;
+      if (event.agents.length === 1) {
+        // biome-ignore lint/style/noNonNullAssertion: guarded by length === 1
+        const agent = event.agents[0]!;
+        const items = agent.containers.map((c) => `• ${c.name} — ${c.error}`).join('\n');
+        return `❌ Update Failed — ${agent.agentName}\n\n${items}`;
+      }
+      const totalContainers = event.agents.reduce((sum, a) => sum + a.containers.length, 0);
+      const sections = event.agents
+        .map((agent) => {
+          const items = agent.containers.map((c) => `  • ${c.name} — ${c.error}`).join('\n');
+          return `📍 ${agent.agentName}\n${items}`;
+        })
+        .join('\n\n');
+      return `❌ Update Failed — ${event.agents.length} agents, ${totalContainers} containers\n\n${sections}`;
     }
   }
 }

--- a/controller/src/notifications/senders/webhook.ts
+++ b/controller/src/notifications/senders/webhook.ts
@@ -87,9 +87,12 @@ export async function sendWebhook(
     } else if (event.type === 'update_success') {
       payload = {
         ...event,
-        containers: event.containers.map((c) => ({
-          ...c,
-          link: renderImageLink(c.image, linkTpl),
+        agents: event.agents.map((a) => ({
+          ...a,
+          containers: a.containers.map((c) => ({
+            ...c,
+            link: renderImageLink(c.image, linkTpl),
+          })),
         })),
       };
     } else {

--- a/controller/src/notifications/session-batcher.ts
+++ b/controller/src/notifications/session-batcher.ts
@@ -10,123 +10,102 @@ interface UpdateResultItem {
   durationMs: number;
 }
 
-// Batch update results per agent — accumulate for a short window, then dispatch
-// a single notification with all containers from the same update operation.
-interface ResultBatch {
-  agentId: string;
-  successes: Array<{ name: string; image: string; durationMs: number }>;
-  failures: Array<{ name: string; error: string }>;
-  expectedCount: number; // 0 = unknown, flush on timer; >0 = flush when count reached
+// Cross-agent update result batch — accumulate results from all agents within
+// a sliding window, then dispatch a single consolidated notification.
+interface UpdateBatch {
+  agents: Map<
+    string,
+    {
+      successes: Array<{ name: string; image: string; durationMs: number }>;
+      failures: Array<{ name: string; error: string }>;
+    }
+  >;
   timer: ReturnType<typeof setTimeout>;
   maxTimer: ReturnType<typeof setTimeout>;
-  createdAt: number;
 }
 
-const resultBatches = new Map<string, ResultBatch>();
-// Fallback timers in case expectedCount is not set or results are lost
-const RESULT_BATCH_WINDOW_MS = 15_000; // wait 15s after last result
-const RESULT_BATCH_MAX_WAIT_MS = 5 * 60_000; // max 5 minutes
+let pendingUpdateBatch: UpdateBatch | null = null;
+const UPDATE_BATCH_WINDOW_MS = 30_000; // wait 30s after last result
+const UPDATE_BATCH_MAX_WAIT_MS = 5 * 60_000; // max 5 minutes
 
-function flushResultBatch(agentId: string): void {
-  const batch = resultBatches.get(agentId);
-  if (!batch) return;
-  clearTimeout(batch.timer);
-  clearTimeout(batch.maxTimer);
-  resultBatches.delete(agentId);
+function flushUpdateBatch(): void {
+  if (!pendingUpdateBatch) return;
+  clearTimeout(pendingUpdateBatch.timer);
+  clearTimeout(pendingUpdateBatch.maxTimer);
 
-  if (batch.successes.length > 0) {
+  const batch = pendingUpdateBatch;
+  pendingUpdateBatch = null;
+
+  const succAgents: Array<{
+    agentName: string;
+    containers: Array<{ name: string; image: string; durationMs: number }>;
+  }> = [];
+  const failAgents: Array<{
+    agentName: string;
+    containers: Array<{ name: string; error: string }>;
+  }> = [];
+
+  for (const [agentName, data] of batch.agents) {
+    if (data.successes.length > 0) {
+      succAgents.push({ agentName, containers: data.successes });
+    }
+    if (data.failures.length > 0) {
+      failAgents.push({ agentName, containers: data.failures });
+    }
+  }
+
+  if (succAgents.length > 0) {
     notifier
-      .dispatch({
-        type: 'update_success',
-        agentName: batch.agentId,
-        containers: batch.successes,
-      })
+      .dispatch({ type: 'update_success', agents: succAgents })
       .catch((err) => log.error('notify', `dispatch failed: ${err}`));
   }
-
-  if (batch.failures.length > 0) {
+  if (failAgents.length > 0) {
     notifier
-      .dispatch({
-        type: 'update_failed',
-        agentName: batch.agentId,
-        containers: batch.failures,
-      })
+      .dispatch({ type: 'update_failed', agents: failAgents })
       .catch((err) => log.error('notify', `dispatch failed: ${err}`));
   }
-}
-
-/**
- * Tell the batcher how many update results to expect for an agent.
- * When all results arrive, the batch flushes immediately — no timer wait.
- * Call this BEFORE the UPDATE command is sent to the agent.
- */
-export function expectUpdateResults(agentId: string, count: number): void {
-  let batch = resultBatches.get(agentId);
-  if (!batch) {
-    const maxTimer = setTimeout(() => flushResultBatch(agentId), RESULT_BATCH_MAX_WAIT_MS);
-    maxTimer.unref?.();
-    batch = {
-      agentId,
-      successes: [],
-      failures: [],
-      expectedCount: count,
-      timer: setTimeout(() => flushResultBatch(agentId), RESULT_BATCH_WINDOW_MS),
-      maxTimer,
-      createdAt: Date.now(),
-    };
-    batch.timer.unref?.();
-    resultBatches.set(agentId, batch);
-  } else {
-    batch.expectedCount = count;
-  }
-  log.info('notify', `expecting ${count} update result(s) for agent ${agentId}`);
 }
 
 export function addUpdateResult(agentId: string, result: UpdateResultItem): void {
-  let batch = resultBatches.get(agentId);
-  if (!batch) {
-    const maxTimer = setTimeout(() => flushResultBatch(agentId), RESULT_BATCH_MAX_WAIT_MS);
+  if (!pendingUpdateBatch) {
+    const maxTimer = setTimeout(() => flushUpdateBatch(), UPDATE_BATCH_MAX_WAIT_MS);
     maxTimer.unref?.();
-    batch = {
-      agentId,
-      successes: [],
-      failures: [],
-      expectedCount: 0,
-      timer: setTimeout(() => flushResultBatch(agentId), RESULT_BATCH_WINDOW_MS),
+    pendingUpdateBatch = {
+      agents: new Map(),
+      timer: setTimeout(() => flushUpdateBatch(), UPDATE_BATCH_WINDOW_MS),
       maxTimer,
-      createdAt: Date.now(),
     };
-    batch.timer.unref?.();
-    resultBatches.set(agentId, batch);
+    pendingUpdateBatch.timer.unref?.();
   } else {
     // Sliding window: reset the timer on each new result
-    clearTimeout(batch.timer);
-    batch.timer = setTimeout(() => flushResultBatch(agentId), RESULT_BATCH_WINDOW_MS);
-    batch.timer.unref?.();
+    clearTimeout(pendingUpdateBatch.timer);
+    pendingUpdateBatch.timer = setTimeout(() => flushUpdateBatch(), UPDATE_BATCH_WINDOW_MS);
+    pendingUpdateBatch.timer.unref?.();
   }
 
+  if (!pendingUpdateBatch.agents.has(agentId)) {
+    pendingUpdateBatch.agents.set(agentId, { successes: [], failures: [] });
+  }
+  // biome-ignore lint/style/noNonNullAssertion: key was just set above
+  const agentData = pendingUpdateBatch.agents.get(agentId)!;
+
   if (result.success) {
-    batch.successes.push({
+    agentData.successes.push({
       name: result.containerName,
       image: result.image ?? '',
       durationMs: result.durationMs,
     });
   } else {
-    batch.failures.push({
+    agentData.failures.push({
       name: result.containerName,
       error: result.error ?? 'unknown',
     });
   }
 
-  // If we know how many results to expect and all have arrived, flush immediately
-  const totalReceived = batch.successes.length + batch.failures.length;
-  if (batch.expectedCount > 0 && totalReceived >= batch.expectedCount) {
-    log.info(
-      'notify',
-      `all ${totalReceived}/${batch.expectedCount} update results received for ${agentId} — flushing`,
-    );
-    flushResultBatch(agentId);
-  }
+  log.info(
+    'notify',
+    `update result for ${agentId}: ${result.success ? 'success' : 'failed'} — ${result.containerName}`,
+  );
 }
 
 // Deduplicate: track which container updates we already notified about
@@ -156,21 +135,23 @@ function pruneNotified(): void {
 // Periodic pruning of stale dedup entries (runs every 10 minutes)
 setInterval(pruneNotified, 10 * 60 * 1000).unref();
 
-/** Flush pending batch and clear timer (call during shutdown). */
+/** Flush pending batches and clear timers (call during shutdown). */
 export function clearPendingTimers(): void {
   if (pendingCheckBatch) {
     clearTimeout(pendingCheckBatch.timer);
     flushCheckBatch(); // flush before discarding
   }
-  // Flush any pending update result batches
-  for (const [agentId] of resultBatches) {
-    flushResultBatch(agentId);
+  if (pendingUpdateBatch) {
+    clearTimeout(pendingUpdateBatch.timer);
+    clearTimeout(pendingUpdateBatch.maxTimer);
+    flushUpdateBatch();
   }
 }
 
 // Batch check results across agents — accumulate before dispatching a single notification.
 // When expectedAgents is set (multi-agent check), wait for all agents OR timeout.
-// Otherwise use a default window so isolated single-agent checks still batch reasonably.
+// Otherwise use a 90s sliding window so agents with close-but-not-identical schedules
+// still batch into a single notification.
 interface CheckBatch {
   agents: Array<{
     agentName: string;
@@ -182,8 +163,11 @@ interface CheckBatch {
 }
 
 let pendingCheckBatch: CheckBatch | null = null;
-const CHECK_BATCH_WINDOW_MS = 5_000; // default window for single-agent checks
-const CHECK_BATCH_MAX_WAIT_MS = 30_000; // max wait when expecting multiple agents
+// 90s sliding window: agents checking within 90s of each other batch into one notification.
+// This covers agents on the same schedule with per-agent jitter or slightly offset cron
+// expressions (e.g. "0 7 * * *" vs "1 7 * * *").
+const CHECK_BATCH_WINDOW_MS = 90_000;
+const CHECK_BATCH_MAX_WAIT_MS = 30_000; // max wait when expecting multiple agents via expectCheckResults
 
 function flushCheckBatch(): void {
   if (!pendingCheckBatch || pendingCheckBatch.agents.length === 0) {
@@ -273,6 +257,10 @@ export function dispatchCheckResults(
       expectedAgentCount: 0,
       timer: setTimeout(flushCheckBatch, CHECK_BATCH_WINDOW_MS),
     };
+  } else if (pendingCheckBatch.expectedAgentCount === 0) {
+    // Sliding window for unknown-count batches: reset timer on each new agent
+    clearTimeout(pendingCheckBatch.timer);
+    pendingCheckBatch.timer = setTimeout(flushCheckBatch, CHECK_BATCH_WINDOW_MS);
   }
 
   if (agentId) {

--- a/controller/src/scheduler/orchestrator.ts
+++ b/controller/src/scheduler/orchestrator.ts
@@ -1,5 +1,4 @@
-import { getAgent, getContainersByAgent } from '../db/queries.js';
-import { expectUpdateResults } from '../notifications/session-batcher.js';
+import { getContainersByAgent } from '../db/queries.js';
 import type { Container } from '../types.js';
 import type { AgentHub } from '../ws/hub.js';
 
@@ -129,12 +128,6 @@ export async function executeOrchestratedUpdate(
 ): Promise<void> {
   const batches = await resolveUpdateBatches(agentId, containerIds);
   const strategy = options?.strategy ?? 'stop-first';
-
-  // Tell the notification batcher how many results to expect so it can
-  // flush a single combined message once all containers report back.
-  const agentRecord = await getAgent(agentId);
-  const agentDisplayName = agentRecord?.name ?? agentId;
-  expectUpdateResults(agentDisplayName, containerIds.length);
 
   if (batches.length <= 1) {
     // Single batch or no labels — use regular UPDATE

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -606,11 +606,15 @@ export class AgentHub {
                   const { notifier } = await import('../notifications/notifier.js');
                   await notifier.dispatch({
                     type: 'update_failed',
-                    agentName,
-                    containers: containerNames.map((name) => ({
-                      name,
-                      error: `Auto-rolled back: ${reason}`,
-                    })),
+                    agents: [
+                      {
+                        agentName,
+                        containers: containerNames.map((name) => ({
+                          name,
+                          error: `Auto-rolled back: ${reason}`,
+                        })),
+                      },
+                    ],
                   });
                 } catch (err) {
                   log.error('hub', `Failed to dispatch auto-rollback notification: ${err}`);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -142,13 +142,17 @@ export type NotificationEvent =
     }
   | {
       type: 'update_success';
-      agentName: string;
-      containers: Array<{ name: string; image: string; durationMs: number }>;
+      agents: Array<{
+        agentName: string;
+        containers: Array<{ name: string; image: string; durationMs: number }>;
+      }>;
     }
   | {
       type: 'update_failed';
-      agentName: string;
-      containers: Array<{ name: string; error: string }>;
+      agents: Array<{
+        agentName: string;
+        containers: Array<{ name: string; error: string }>;
+      }>;
     };
 
 export interface NotificationChannel {


### PR DESCRIPTION
## Summary

- **Updates Available**: Increased `CHECK_BATCH_WINDOW_MS` from 5 s to 90 s (sliding window), so agents checking within 90 seconds of each other — whether on the same schedule, with schedule offsets, or individual overrides — produce a single notification instead of one per agent
- **Update Complete**: Replaced per-agent `resultBatches` map with a single global cross-agent update batch (30 s sliding window + 5 min max). Results from all agents accumulate before a consolidated notification groups successes and failures by agent
- **Type change**: `update_success` and `update_failed` events now use the same `agents[]` array structure as `update_available`, enabling multi-agent grouping in all senders (Telegram, ntfy, Slack, webhook)

**Before:** pi-hole-01 at 07:00 → separate notification; plex at 07:01 → separate notification; plex update at 17:23 → separate notification; servarr update at 17:23 → separate notification

**After:** pi-hole-01 + plex batched into one "Updates Available" notification; plex + servarr batched into one "Update Complete" notification

## Test plan

- [ ] All 229 existing tests pass (`npm test`)
- [ ] New `update result batching` test suite (4 tests) covers cross-agent consolidation, success/failure split, sliding window reset, and shutdown flush
- [ ] Manual: trigger updates on two agents simultaneously — verify single Telegram message with both agents listed under `✅ Update Complete — 2 agents`
- [ ] Manual: schedule check fires for multiple agents — verify single `🔔 Updates Available` notification grouping all agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)