### PR TITLE
fix(agent): improve self-container detection with fallback methods and late retry

### DIFF
--- a/agent/docker.go
+++ b/agent/docker.go
@@ -24,30 +24,70 @@ import (
 // getSelfContainerID returns the full Docker container ID of the agent process,
 // or empty string if not running in a container.
 //
-// Primary: parse /proc/self/cgroup — reliable across standalone Docker and
-// Docker Compose. Compose sets HOSTNAME to the service name, not the container
-// ID, so the HOSTNAME approach fails there.
+// Tries four methods in order:
+//  1. /proc/self/cgroup — works with cgroupv1 and cgroupv2 without private namespace.
+//  2. /proc/1/cpuset — an alternative cgroupv1 path that some kernels expose.
+//  3. HOSTNAME env var — Docker sets this to the 12-char short container ID by
+//     default; also works when the user has set an explicit hostname.
+//  4. os.Hostname() syscall — same value as HOSTNAME but bypasses env var.
 //
-// Fallback: use HOSTNAME for environments where cgroups are unavailable
-// (e.g. non-Linux hosts or very old kernels).
+// Note: cgroupv2 with --cgroupns=private (Docker 20.10+ default) makes the
+// cgroup paths appear as "0::/" inside the container. In that case methods 1
+// and 2 return "" and the fallbacks are used.
 func getSelfContainerID(ctx context.Context, cli DockerAPI) string {
+	containerID := func(info container.InspectResponse) string {
+		if info.ContainerJSONBase == nil {
+			return ""
+		}
+		return info.ID
+	}
+
+	// Method 1: /proc/self/cgroup (cgroupv1 and cgroupv2 without private NS)
 	if data, err := os.ReadFile("/proc/self/cgroup"); err == nil {
 		if id := extractContainerIDFromCgroup(string(data)); id != "" {
 			if info, err := cli.ContainerInspect(ctx, id); err == nil {
-				return info.ID
+				if id := containerID(info); id != "" {
+					return id
+				}
 			}
 		}
 	}
 
-	hostname := os.Getenv("HOSTNAME")
-	if hostname == "" || len(hostname) < 12 {
-		return ""
+	// Method 2: /proc/1/cpuset — alternative cgroupv1 path, format "/docker/<64hex>"
+	if data, err := os.ReadFile("/proc/1/cpuset"); err == nil {
+		for _, seg := range strings.Split(strings.TrimSpace(string(data)), "/") {
+			if len(seg) == 64 && isLowercaseHex(seg) {
+				if info, err := cli.ContainerInspect(ctx, seg); err == nil {
+					if id := containerID(info); id != "" {
+						return id
+					}
+				}
+			}
+		}
 	}
-	info, err := cli.ContainerInspect(ctx, hostname)
-	if err != nil {
-		return ""
+
+	// Method 3: HOSTNAME env var — Docker sets this to the short container ID
+	// (12 hex chars) unless an explicit hostname is configured. Also handles
+	// explicit hostnames (e.g. service name in Compose).
+	if hostname := os.Getenv("HOSTNAME"); hostname != "" {
+		if info, err := cli.ContainerInspect(ctx, hostname); err == nil {
+			if id := containerID(info); id != "" {
+				return id
+			}
+		}
 	}
-	return info.ID
+
+	// Method 4: os.Hostname() syscall — identical to HOSTNAME in containers but
+	// works even if the env var was stripped.
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		if info, err := cli.ContainerInspect(ctx, hostname); err == nil {
+			if id := containerID(info); id != "" {
+				return id
+			}
+		}
+	}
+
+	return ""
 }
 
 // extractContainerIDFromCgroup scans cgroup entries for a 64-char hex container

--- a/agent/managed.go
+++ b/agent/managed.go
@@ -158,10 +158,28 @@ func runManagedMode(cfg *AgentConfig, credStore *CredStore, dockerClient *Docker
 
 		// Separate self-update from other containers — self must run LAST
 		// because the agent process will die during self-update.
+		//
+		// If self-detection failed at startup (selfContainerID empty), retry now.
+		// This handles transient failures (Docker socket not ready at boot) and
+		// environments where cgroup v2 private namespace makes startup detection fail.
+		if updater.selfContainerID == "" {
+			if detected := getSelfContainerID(context.Background(), dockerClient.cli); detected != "" {
+				updater.selfContainerID = detected
+				log.Printf("[handler] late self-detection succeeded: %s", detected[:12])
+			}
+		}
+
 		var normalIDs []string
 		var selfID string
 		for _, id := range cmd.ContainerIDs {
-			if updater.IsSelfContainer(id) {
+			// Resolve stale container IDs — the controller may hold an old Docker ID
+			// from before a previous recreation. IsSelfContainer compares against the
+			// current container ID, so a stale ID would fail the check.
+			resolved := id
+			if r, err := dockerClient.ResolveContainerID(ctx, id); err == nil {
+				resolved = r
+			}
+			if updater.IsSelfContainer(id) || updater.IsSelfContainer(resolved) {
 				selfID = id
 			} else {
 				normalIDs = append(normalIDs, id)
@@ -240,12 +258,26 @@ func runManagedMode(cfg *AgentConfig, credStore *CredStore, dockerClient *Docker
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancel()
 
+		// Retry self-detection if it failed at startup (same logic as UPDATE handler).
+		if updater.selfContainerID == "" {
+			if detected := getSelfContainerID(context.Background(), dockerClient.cli); detected != "" {
+				updater.selfContainerID = detected
+				log.Printf("[handler] late self-detection succeeded: %s", detected[:12])
+			}
+		}
+
 		// Collect the self-container ID if it appears in any batch — it must run
 		// last via SelfUpdate (not UpdateContainer), same as the UPDATE handler.
+		// Resolve stale IDs before comparing so a previously-recreated container
+		// still matches selfContainerID.
 		var selfID string
 		for _, batch := range cmd.Batches {
 			for _, id := range batch.ContainerIDs {
-				if updater.IsSelfContainer(id) {
+				resolved := id
+				if r, err := dockerClient.ResolveContainerID(ctx, id); err == nil {
+					resolved = r
+				}
+				if updater.IsSelfContainer(id) || updater.IsSelfContainer(resolved) {
 					selfID = id
 				}
 			}

--- a/agent/updater.go
+++ b/agent/updater.go
@@ -51,6 +51,8 @@ func NewUpdater(docker *DockerClient) *Updater {
 	selfID := getSelfContainerID(context.Background(), docker.cli)
 	if selfID != "" {
 		log.Printf("[updater] detected self container ID: %s", selfID[:12])
+	} else {
+		log.Printf("[updater] WARNING: could not detect self container ID — self-update will use SelfUpdate path only if re-detection at update time succeeds; check cgroup/HOSTNAME accessibility")
 	}
 	return &Updater{
 		docker:          docker,


### PR DESCRIPTION
## Summary

- Extends `getSelfContainerID` from 2 methods to 4, handling more deployment configurations:
  1. `/proc/self/cgroup` — cgroupv1 and cgroupv2 without private namespace
  2. `/proc/1/cpuset` — alternative cgroupv1 path
  3. `HOSTNAME` env var — Docker default (short container ID) and explicit hostnames
  4. `os.Hostname()` syscall — works even when `HOSTNAME` env var is stripped
- Fixes cgroupv2 + `--cgroupns=private` environments (Docker 20.10+ default) where cgroup paths appear as `0::/` and the first two methods fail
- Adds late self-detection retry in `UPDATE` and `BATCHED_UPDATE` handlers: if startup detection failed (transient boot-time race), retries at command time
- Resolves stale container IDs via `ResolveContainerID` before `IsSelfContainer` comparison, handling the case where the controller holds an old Docker ID from a previous recreation
- Guards `ContainerJSONBase` nil-dereference in all four inspect paths

## Test plan

- [ ] `go test ./...` in `agent/` — all 167 tests pass
- [ ] Deploy agent in a Docker Compose stack on a cgroupv2 host and verify self-update works correctly
- [ ] Verify agent self-update still works on cgroupv1 hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)