### PR TITLE
fix(ui): show update progress and tooltip in dashboard agents grid

### DIFF
--- a/ui/src/components/agents/AgentCard.tsx
+++ b/ui/src/components/agents/AgentCard.tsx
@@ -4,6 +4,8 @@ import { StatusDot } from '@/components/common/StatusDot';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useStore } from '@/store/useStore';
 
 interface AgentCardProps {
   agent: Agent;
@@ -16,12 +18,41 @@ export function AgentCard({ agent, checking, onCheck, onUpdate }: AgentCardProps
   const containerCount = agent.containers?.length ?? 0;
   const updateCount = agent.containers?.filter((c) => c.has_update)?.length ?? 0;
 
+  const allProgress = useStore((s) => s.updateProgress);
+  const agentProgress = Object.entries(allProgress).filter(([key]) =>
+    key.startsWith(`${agent.id}:`),
+  );
+  const isUpdating = agentProgress.length > 0;
+
+  const overlayActive = checking || isUpdating;
+  const overlayLabel = checking ? 'Checking...' : 'Updating...';
+
+  const tooltipLines = agentProgress.map(([, p]) => `${p.containerName}: ${p.step}`);
+
   return (
     <Card className="card-hover h-full flex flex-col relative overflow-hidden">
-      {checking && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px] rounded-xl">
-          <Loader2 className="size-8 animate-spin text-primary" />
-        </div>
+      {overlayActive && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-1.5 bg-background/60 backdrop-blur-[1px] rounded-xl cursor-default" />
+              }
+            >
+              <Loader2 className="size-8 animate-spin text-primary" />
+              <span className="text-xs text-primary font-medium">{overlayLabel}</span>
+            </TooltipTrigger>
+            {isUpdating && tooltipLines.length > 0 && (
+              <TooltipContent side="bottom">
+                <div className="flex flex-col gap-0.5">
+                  {tooltipLines.map((line) => (
+                    <span key={line}>{line}</span>
+                  ))}
+                </div>
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
       )}
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
@@ -75,7 +106,7 @@ export function AgentCard({ agent, checking, onCheck, onUpdate }: AgentCardProps
               e.stopPropagation();
               onCheck?.();
             }}
-            disabled={checking}
+            disabled={checking || isUpdating}
           >
             <RefreshCw size={14} className={checking ? 'animate-spin' : ''} />
             {checking ? 'Checking...' : 'Check'}
@@ -87,6 +118,7 @@ export function AgentCard({ agent, checking, onCheck, onUpdate }: AgentCardProps
               e.stopPropagation();
               onUpdate?.();
             }}
+            disabled={isUpdating}
           >
             <ArrowUpCircle size={14} />
             Update All

--- a/ui/src/components/agents/AgentListRow.tsx
+++ b/ui/src/components/agents/AgentListRow.tsx
@@ -6,6 +6,8 @@ import { StatusDot } from '@/components/common/StatusDot';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TableCell, TableRow } from '@/components/ui/table';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useStore } from '@/store/useStore';
 
 interface AgentListRowProps {
   agent: Agent;
@@ -19,6 +21,20 @@ export function AgentListRow({ agent, checking, onCheck, onUpdate, onDelete }: A
   const containerCount = agent.containers?.length ?? 0;
   const updateCount = agent.containers?.filter((c) => c.has_update)?.length ?? 0;
 
+  const allProgress = useStore((s) => s.updateProgress);
+  const agentProgress = Object.entries(allProgress).filter(([key]) =>
+    key.startsWith(`${agent.id}:`),
+  );
+  const isUpdating = agentProgress.length > 0;
+  const tooltipLines = agentProgress.map(([, p]) => `${p.containerName}: ${p.step}`);
+
+  const statusIcon =
+    checking || isUpdating ? (
+      <Loader2 className="size-3.5 animate-spin text-primary shrink-0" />
+    ) : (
+      <StatusDot status={agent.status} />
+    );
+
   return (
     <TableRow className="group">
       <TableCell>
@@ -26,12 +42,28 @@ export function AgentListRow({ agent, checking, onCheck, onUpdate, onDelete }: A
           to={`/agents/${agent.id}`}
           className="flex items-center gap-2 hover:text-primary transition-colors"
         >
-          {checking ? (
-            <Loader2 className="size-3.5 animate-spin text-primary shrink-0" />
+          {isUpdating && tooltipLines.length > 0 ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger render={<span className="flex items-center gap-2" />}>
+                  {statusIcon}
+                  <span className="font-medium">{agent.name}</span>
+                </TooltipTrigger>
+                <TooltipContent side="right">
+                  <div className="flex flex-col gap-0.5">
+                    {tooltipLines.map((line) => (
+                      <span key={line}>{line}</span>
+                    ))}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : (
-            <StatusDot status={agent.status} />
+            <>
+              {statusIcon}
+              <span className="font-medium">{agent.name}</span>
+            </>
           )}
-          <span className="font-medium">{agent.name}</span>
         </Link>
       </TableCell>
       <TableCell className="hidden md:table-cell text-muted-foreground">{agent.hostname}</TableCell>
@@ -67,7 +99,7 @@ export function AgentListRow({ agent, checking, onCheck, onUpdate, onDelete }: A
               e.preventDefault();
               onCheck();
             }}
-            disabled={checking}
+            disabled={checking || isUpdating}
             aria-label="Check for updates"
           >
             <RefreshCw size={12} className={checking ? 'animate-spin' : ''} />
@@ -79,7 +111,9 @@ export function AgentListRow({ agent, checking, onCheck, onUpdate, onDelete }: A
               e.preventDefault();
               onUpdate();
             }}
+            disabled={isUpdating}
           >
+            {isUpdating ? <Loader2 size={12} className="animate-spin" /> : null}
             Update
           </Button>
           {agent.status === 'offline' && onDelete && (


### PR DESCRIPTION
## Summary

- Fixes #— (no issue filed; discovered by user testing)
- `AgentCard` and `AgentListRow` were not connected to the `updateProgress` store, so clicking **Update All** on the dashboard produced no visual feedback
- Both components now read `updateProgress` entries keyed by `${agentId}:*` to derive an `isUpdating` flag

## Changes

**AgentCard** (grid view):
- Shows a spinner overlay (identical to the checking overlay) with "Updating..." label while any container on the agent is updating
- Tooltip on the overlay lists each container and its current step (e.g. `nginx: pulling`, `redis: stopping`)
- Disables Check and Update All buttons while updating

**AgentListRow** (list view):
- Replaces the status dot with an animated spinner while updating
- Wraps the agent name row in a tooltip showing container/step progress
- Disables Check and Update buttons while updating; Update button shows a spinner icon

## Test plan

- [ ] `npm test` — all 65 tests pass
- [ ] Trigger **Update All** from the dashboard; verify grid cards show the spinner overlay and tooltip with live step names
- [ ] Verify spinner clears and buttons re-enable once `UPDATE_COMPLETE` is received
- [ ] Verify list view row shows spinner + tooltip during update

🤖 Generated with [Claude Code](https://claude.com/claude-code)