### PR TITLE
Fix: visual 'updating all' bug when updating single container

### DIFF
--- a/controller/src/scheduler/orchestrator.ts
+++ b/controller/src/scheduler/orchestrator.ts
@@ -129,6 +129,21 @@ export async function executeOrchestratedUpdate(
   const batches = await resolveUpdateBatches(agentId, containerIds);
   const strategy = options?.strategy ?? 'stop-first';
 
+  // Broadcast 'queued' status for all target containers to the UI
+  for (const b of batches) {
+    for (let i = 0; i < b.containerIds.length; i++) {
+      const containerId = b.containerIds[i];
+      const containerName = b.containerNames[i];
+      hub.broadcast({
+        type: 'UPDATE_PROGRESS',
+        agentId,
+        containerId,
+        containerName,
+        step: 'queued',
+      });
+    }
+  }
+
   if (batches.length <= 1) {
     // Single batch or no labels — use regular UPDATE
     hub.sendToAgent(agentId, {

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -143,6 +143,10 @@ export class AgentHub {
     this.broadcaster = broadcaster;
   }
 
+  broadcast(event: any): void {
+    this.broadcaster?.broadcast(event);
+  }
+
   handleConnection(socket: WebSocket): void {
     let authenticated = false;
     let agentId: string | null = null;

--- a/ui/src/components/agents/ContainerRow.tsx
+++ b/ui/src/components/agents/ContainerRow.tsx
@@ -154,9 +154,6 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
 
   const progressKey = `${agentId}:${container.docker_id}`;
   const progress = useStore((s) => s.updateProgress[progressKey]);
-  const agentHasActiveUpdate = useStore((s) =>
-    Object.keys(s.updateProgress).some((k) => k.startsWith(`${agentId}:`)),
-  );
   const addToast = useStore((s) => s.addToast);
   const checkingAgents = useStore((s) => s.checkingAgents);
   const checkContainer = useCheckContainer();
@@ -582,26 +579,28 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
         {/* Action buttons */}
         <div className="shrink-0">
           {progress ? (
-            <div className="flex items-center gap-1">
-              {STEPS.map((s) => (
-                <span
-                  key={s}
-                  className={`w-1.5 h-1.5 rounded-full ${
-                    s === progress.step
-                      ? 'bg-primary animate-pulse'
-                      : STEPS.indexOf(s) < STEPS.indexOf(progress.step as (typeof STEPS)[number])
-                        ? 'bg-success'
-                        : 'bg-border'
-                  }`}
-                />
-              ))}
-              <span className="text-[10px] text-primary ml-1">{progress.step}</span>
-            </div>
-          ) : agentHasActiveUpdate && hasUpdate && !isExcluded && !isPinned ? (
-            <div className="flex items-center gap-1">
-              <Loader2 size={12} className="animate-spin text-muted-foreground" />
-              <span className="text-[10px] text-muted-foreground">queued</span>
-            </div>
+            progress.step === 'queued' ? (
+              <div className="flex items-center gap-1">
+                <Loader2 size={12} className="animate-spin text-muted-foreground" />
+                <span className="text-[10px] text-muted-foreground">queued</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1">
+                {STEPS.map((s) => (
+                  <span
+                    key={s}
+                    className={`w-1.5 h-1.5 rounded-full ${
+                      s === progress.step
+                        ? 'bg-primary animate-pulse'
+                        : STEPS.indexOf(s) < STEPS.indexOf(progress.step as (typeof STEPS)[number])
+                          ? 'bg-success'
+                          : 'bg-border'
+                    }`}
+                  />
+                ))}
+                <span className="text-[10px] text-primary ml-1">{progress.step}</span>
+              </div>
+            )
           ) : (
             <TooltipProvider>
               <div className="flex items-center gap-0.5">


### PR DESCRIPTION
## Description

Fixes a visual bug in the dashboard where triggering an update for a single container caused all other containers with pending updates on the same agent to falsely display a "queued" status with a loading spinner.

### What was happening:
The frontend was using a coarse helper `agentHasActiveUpdate` which evaluated to `true` if *any* container on the agent was currently updating. As a result, *all* other containers that had updates available and were not pinned/excluded entered the `queued` UI branch and showed a spinner, even if they were not actually queued or being updated.

### Solution:
1. **Controller Queue Broadcasting**: Added a public `broadcast(event: any): void` helper to `AgentHub` inside `controller/src/ws/hub.ts`.
2. **Orchestration**: Updated `executeOrchestratedUpdate` inside `controller/src/scheduler/orchestrator.ts` to explicitly broadcast an `UPDATE_PROGRESS` event with step `'queued'` for all target containers inside the update batches before issuing commands to the agent.
3. **Frontend UI**: Removed the coarse `agentHasActiveUpdate` check from `ui/src/components/agents/ContainerRow.tsx` and updated it to explicitly handle and render the `'queued'` progress step.

Now, only containers that are actually in the update queue display the "queued" status and spinner.