### PR TITLE
Fix broken Managed Mode docs example, add email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ WatchWarden is currently in an **early-adopter / beta** stage.
 - **Diagnostics bundle** — downloadable ZIP from Settings → About containing controller info, agent statuses, registry credential summary (passwords redacted), anonymous Docker Hub image list, and recent controller logs
 
 ### Notifications
-- **Telegram, Slack, Webhook, ntfy** — configurable channels with batched, deduplicated messages
+- **Telegram, Slack, Webhook, ntfy, Email** — configurable channels with batched, deduplicated messages
 - **Notification templates** — customize message format with Go text/template (`WW_NOTIFICATION_TEMPLATE`)
 - **Link templates** — auto-generated links to Docker Hub, GHCR, or Quay.io tag pages in notifications
 - **Auto-rollback alerts** — notifies when a container is automatically rolled back

--- a/controller/package.json
+++ b/controller/package.json
@@ -27,6 +27,7 @@
     "fastify": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "node-cron": "^3.0.3",
+    "nodemailer": "^9.0.3",
     "pino-pretty": "^13.1.3",
     "postgres": "^3.4.8",
     "uuid": "^11.0.3"
@@ -38,6 +39,7 @@
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^22.10.0",
     "@types/node-cron": "^3.0.11",
+    "@types/nodemailer": "^8.0.1",
     "@types/uuid": "^10.0.0",
     "@types/ws": "^8.5.13",
     "testcontainers": "^11.13.0",

--- a/controller/src/db/__tests__/client.test.ts
+++ b/controller/src/db/__tests__/client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { closeSql, initSql } from '../client.js';
+
+describe('initSql', () => {
+  it('throws a clear, actionable error when DATABASE_URL contains an unescaped special character', async () => {
+    // postgres.js parses the connection string with `new URL()` — a raw `/` in the
+    // password breaks URL parsing and throws a bare "TypeError: Invalid URL".
+    expect(() => initSql('postgresql://watchwarden:pa/ss@localhost:5432/watchwarden')).toThrow(
+      /DATABASE_URL is not a valid connection string.*POSTGRES_PASSWORD.*openssl rand -hex 32/s,
+    );
+  });
+
+  it('throws the required-env-var error when no connection string is available', () => {
+    const original = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      expect(() => initSql()).toThrow('DATABASE_URL environment variable is required');
+    } finally {
+      if (original !== undefined) process.env.DATABASE_URL = original;
+    }
+  });
+
+  it('initializes normally for a well-formed connection string', async () => {
+    const client = initSql('postgresql://watchwarden:watchwarden@localhost:5432/watchwarden');
+    expect(client).toBeDefined();
+    await closeSql();
+  });
+});

--- a/controller/src/db/client.ts
+++ b/controller/src/db/client.ts
@@ -5,14 +5,25 @@ let _sql: ReturnType<typeof postgres> | null = null;
 export function initSql(connectionString?: string): ReturnType<typeof postgres> {
   const url = connectionString ?? process.env.DATABASE_URL;
   if (!url) throw new Error('DATABASE_URL environment variable is required');
-  // DB-03: statement_timeout prevents a slow or deadlocked query from holding
-  // a connection indefinitely and exhausting the pool (max: 10) under load.
-  _sql = postgres(url, {
-    max: 10,
-    idle_timeout: 30,
-    connect_timeout: 10,
-    connection: { statement_timeout: 30_000 },
-  });
+  try {
+    // DB-03: statement_timeout prevents a slow or deadlocked query from holding
+    // a connection indefinitely and exhausting the pool (max: 10) under load.
+    _sql = postgres(url, {
+      max: 10,
+      idle_timeout: 30,
+      connect_timeout: 10,
+      connection: { statement_timeout: 30_000 },
+    });
+  } catch (err) {
+    // postgres.js parses DATABASE_URL with `new URL()` — an unescaped special
+    // character in POSTGRES_PASSWORD (/, #, etc.) throws a bare "Invalid URL"
+    // TypeError here with no indication of the actual cause.
+    throw new Error(
+      'DATABASE_URL is not a valid connection string. If POSTGRES_PASSWORD contains ' +
+        String.raw`special characters (/, @, :, #, %, \), URL-encode them or regenerate with ` +
+        `\`openssl rand -hex 32\`. Original error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   return _sql;
 }
 

--- a/controller/src/notifications/__tests__/email.test.ts
+++ b/controller/src/notifications/__tests__/email.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationEvent } from '../types.js';
+
+const sendMail = vi.fn();
+const createTransport = vi.fn(() => ({ sendMail }));
+
+vi.mock('nodemailer', () => ({
+  default: { createTransport },
+}));
+
+const { sendEmail } = await import('../senders/email.js');
+
+const successEvent: NotificationEvent = {
+  type: 'update_success',
+  agents: [
+    { agentName: 'prod', containers: [{ name: 'app', image: 'app:latest', durationMs: 5000 }] },
+  ],
+};
+
+describe('email sender', () => {
+  beforeEach(() => {
+    sendMail.mockReset().mockResolvedValue(undefined);
+    createTransport.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a transport from host/port/secure and sends to/from/subject/text', async () => {
+    await sendEmail(
+      {
+        host: 'smtp.example.com',
+        port: '587',
+        secure: 'false',
+        from: 'watchwarden@example.com',
+        to: 'me@example.com',
+      },
+      successEvent,
+    );
+
+    expect(createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ host: 'smtp.example.com', port: 587, secure: false }),
+    );
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const [call] = sendMail.mock.calls[0] as [
+      { from: string; to: string; subject: string; text: string },
+    ];
+    expect(call.from).toBe('watchwarden@example.com');
+    expect(call.to).toBe('me@example.com');
+    expect(call.subject).toContain('Update Complete');
+    expect(call.text).toContain('app');
+  });
+
+  it('omits auth when no user is configured', async () => {
+    await sendEmail(
+      { host: 'smtp.example.com', port: '25', from: 'a@example.com', to: 'b@example.com' },
+      successEvent,
+    );
+
+    const [config] = createTransport.mock.calls[0] as unknown as [{ auth?: unknown }];
+    expect(config.auth).toBeUndefined();
+  });
+
+  it('sets auth when user/password are configured', async () => {
+    await sendEmail(
+      {
+        host: 'smtp.example.com',
+        port: '587',
+        user: 'smtpuser',
+        password: 'smtppass',
+        from: 'a@example.com',
+        to: 'b@example.com',
+      },
+      successEvent,
+    );
+
+    const [config] = createTransport.mock.calls[0] as unknown as [
+      { auth?: { user: string; pass: string } },
+    ];
+    expect(config.auth).toEqual({ user: 'smtpuser', pass: 'smtppass' });
+  });
+
+  it('propagates errors from sendMail', async () => {
+    sendMail.mockRejectedValue(new Error('SMTP connection refused'));
+
+    await expect(
+      sendEmail(
+        { host: 'smtp.example.com', port: '587', from: 'a@example.com', to: 'b@example.com' },
+        successEvent,
+      ),
+    ).rejects.toThrow('SMTP connection refused');
+  });
+});

--- a/controller/src/notifications/notifier.ts
+++ b/controller/src/notifications/notifier.ts
@@ -1,6 +1,7 @@
 import { insertNotificationLog, listNotificationChannels } from '../db/queries.js';
 import { decrypt } from '../lib/crypto.js';
 import { log } from '../lib/logger.js';
+import { sendEmail } from './senders/email.js';
 import { sendNtfy } from './senders/ntfy.js';
 import { sendSlack } from './senders/slack.js';
 import { sendTelegram } from './senders/telegram.js';
@@ -110,6 +111,9 @@ class Notifier {
         break;
       case 'ntfy':
         await sendNtfy(config, event, formatOptions);
+        break;
+      case 'email':
+        await sendEmail(config, event, formatOptions);
         break;
     }
   }

--- a/controller/src/notifications/senders/email.ts
+++ b/controller/src/notifications/senders/email.ts
@@ -1,0 +1,42 @@
+import nodemailer from 'nodemailer';
+import type { NotificationEvent } from '../types.js';
+import { type FormatOptions, formatTelegramMessage } from './telegram.js';
+
+function subjectFor(event: NotificationEvent): string {
+  switch (event.type) {
+    case 'update_available':
+      return 'WatchWarden: Updates Available';
+    case 'update_success':
+      return 'WatchWarden: Update Complete';
+    case 'update_failed':
+      return 'WatchWarden: Update Failed';
+  }
+}
+
+export async function sendEmail(
+  config: {
+    host: string;
+    port: string;
+    secure?: string;
+    user?: string;
+    password?: string;
+    from: string;
+    to: string;
+  },
+  event: NotificationEvent,
+  options?: FormatOptions,
+): Promise<void> {
+  const text = formatTelegramMessage(event, options);
+  const transporter = nodemailer.createTransport({
+    host: config.host,
+    port: Number(config.port),
+    secure: config.secure === 'true',
+    auth: config.user ? { user: config.user, pass: config.password } : undefined,
+  });
+  await transporter.sendMail({
+    from: config.from,
+    to: config.to,
+    subject: subjectFor(event),
+    text,
+  });
+}

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -6,7 +6,7 @@
 # Dashboard: http://localhost:8080
 #
 # REQUIRED: Set these environment variables before running:
-#   export POSTGRES_PASSWORD=$(openssl rand -base64 32)
+#   export POSTGRES_PASSWORD=$(openssl rand -hex 32)
 #   export ADMIN_PASSWORD=$(openssl rand -base64 16)
 #   export JWT_SECRET=$(openssl rand -base64 32)
 #   export ENCRYPTION_KEY=$(openssl rand -base64 32)

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "fastify": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "node-cron": "^3.0.3",
+        "nodemailer": "^9.0.3",
         "pino-pretty": "^13.1.3",
         "postgres": "^3.4.8",
         "uuid": "^11.0.3"
@@ -37,6 +38,7 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^22.10.0",
         "@types/node-cron": "^3.0.11",
+        "@types/nodemailer": "^8.0.1",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.5.13",
         "testcontainers": "^11.13.0",
@@ -3177,6 +3179,16 @@
       "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.15",
@@ -7484,6 +7496,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/ui/src/components/notifications/AddChannelModal.tsx
+++ b/ui/src/components/notifications/AddChannelModal.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   Hash,
   Loader2,
+  Mail,
   MessageCircle,
   Plus,
   Webhook,
@@ -65,6 +66,12 @@ const TYPES = [
     label: 'ntfy',
     icon: Bell,
     desc: 'Push to ntfy.sh or self-hosted ntfy',
+  },
+  {
+    value: 'email',
+    label: 'Email',
+    icon: Mail,
+    desc: 'Send via SMTP email',
   },
 ] as const;
 
@@ -184,6 +191,7 @@ export function AddChannelModal({ open, onOpenChange, editChannel }: AddChannelM
     if (type === 'slack') return !!config.webhookUrl;
     if (type === 'webhook') return !!config.url;
     if (type === 'ntfy') return !!config.topic;
+    if (type === 'email') return !!config.host && !!config.port && !!config.from && !!config.to;
     return false;
   };
 
@@ -463,6 +471,78 @@ export function AddChannelModal({ open, onOpenChange, editChannel }: AddChannelM
                     autoComplete="new-password"
                   />
                 </div>
+              </>
+            )}
+
+            {type === 'email' && (
+              <>
+                <div className="flex gap-2">
+                  <div className="space-y-1.5 flex-1">
+                    <Label htmlFor="channel-email-host">SMTP Host</Label>
+                    <Input
+                      id="channel-email-host"
+                      value={config.host ?? ''}
+                      onChange={(e) => setConfigField('host', e.target.value)}
+                      placeholder="smtp.example.com"
+                    />
+                  </div>
+                  <div className="space-y-1.5 w-24">
+                    <Label htmlFor="channel-email-port">Port</Label>
+                    <Input
+                      id="channel-email-port"
+                      value={config.port ?? ''}
+                      onChange={(e) => setConfigField('port', e.target.value)}
+                      placeholder="587"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="channel-email-user">Username (optional)</Label>
+                  <Input
+                    id="channel-email-user"
+                    value={config.user ?? ''}
+                    onChange={(e) => setConfigField('user', e.target.value)}
+                    placeholder="smtp-user"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="channel-email-password">Password (optional)</Label>
+                  <Input
+                    id="channel-email-password"
+                    value={config.password ?? ''}
+                    onChange={(e) => setConfigField('password', e.target.value)}
+                    type="password"
+                    autoComplete="new-password"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="channel-email-from">From Address</Label>
+                  <Input
+                    id="channel-email-from"
+                    value={config.from ?? ''}
+                    onChange={(e) => setConfigField('from', e.target.value)}
+                    placeholder="watchwarden@example.com"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="channel-email-to">To Address(es)</Label>
+                  <Input
+                    id="channel-email-to"
+                    value={config.to ?? ''}
+                    onChange={(e) => setConfigField('to', e.target.value)}
+                    placeholder="you@example.com, team@example.com"
+                  />
+                </div>
+                {/* biome-ignore lint/a11y/noLabelWithoutControl: label wraps Checkbox */}
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <Checkbox
+                    checked={config.secure === 'true'}
+                    onCheckedChange={(checked) =>
+                      setConfigField('secure', checked ? 'true' : 'false')
+                    }
+                  />
+                  <span className="text-sm">Use TLS (usually port 465)</span>
+                </label>
               </>
             )}
 

--- a/ui/src/components/notifications/ChannelCard.tsx
+++ b/ui/src/components/notifications/ChannelCard.tsx
@@ -3,6 +3,7 @@ import {
   Check,
   Hash,
   Loader2,
+  Mail,
   MessageCircle,
   Pencil,
   Send,
@@ -39,6 +40,7 @@ const typeIcons: Record<string, typeof MessageCircle> = {
   slack: Hash,
   webhook: Webhook,
   ntfy: Bell,
+  email: Mail,
 };
 
 const typeColors: Record<string, string> = {
@@ -46,6 +48,7 @@ const typeColors: Record<string, string> = {
   slack: 'text-warning',
   webhook: 'text-muted-foreground',
   ntfy: 'text-success',
+  email: 'text-accent',
 };
 
 const eventConfig: Record<string, { label: string; className: string }> = {

--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -36,7 +36,7 @@ Single binary, no external dependencies. The agent handles everything locally.
 **Components:**
 - **Scheduler** — cron or interval-based check triggers
 - **Updater** — atomic update/rollback with per-container mutex
-- **Notifier** — Telegram, Slack, Webhook, ntfy notifications with custom templates
+- **Notifier** — Telegram, Slack, Webhook, ntfy, Email notifications with custom templates
 - **HTTP Server** — health check + status API
 - **Docker Client** — Docker SDK operations
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -83,6 +83,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U watchwarden"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   controller:
     image: ghcr.io/watchwarden-labs/watchwarden-controller:latest
@@ -120,7 +125,7 @@ volumes:
 Generate secrets and start:
 
 ```bash
-export POSTGRES_PASSWORD=$(openssl rand -base64 32)
+export POSTGRES_PASSWORD=$(openssl rand -hex 32)
 export ADMIN_PASSWORD=$(openssl rand -base64 16)
 export JWT_SECRET=$(openssl rand -base64 32)
 export ENCRYPTION_KEY=$(openssl rand -base64 32)

--- a/website/docs/ui-guide.md
+++ b/website/docs/ui-guide.md
@@ -191,6 +191,7 @@ Supported channels:
 - **Slack** — incoming webhook URL
 - **Webhook** — generic HTTP POST to any URL
 - **ntfy** — self-hosted or ntfy.sh push notifications
+- **Email** — SMTP, with optional auth and TLS
 
 Each channel supports custom templates and per-event filtering (updates available, update success, update failed).
 


### PR DESCRIPTION
## Summary

Fixes #69, which reported a chain of deploy failures when following the Managed Mode docker-compose example in the docs, plus a feature request for email notifications.

- The docs' `postgres` service had no `healthcheck`, so `depends_on: condition: service_healthy` on the controller could never be satisfied — causing "missing dependency" startup failures and prompting users to hand-roll a broken healthcheck that spams `FATAL: role "root" does not exist` in postgres logs
- The docs recommended `openssl rand -base64 32` for `POSTGRES_PASSWORD`, which can emit `/` or `+` — breaking `DATABASE_URL` parsing once interpolated into the connection string and crashing the controller with a bare `TypeError: Invalid URL`. Switched to `-hex 32`, and `db/client.ts` now throws a clear, actionable error for this class of misconfiguration regardless of cause
- Added **email/SMTP** as a new notification channel type (nodemailer-based), following the existing telegram/slack/webhook/ntfy pattern — requested in the issue

One item from the report ("remove `/data` from the postgres_data line") wasn't reproducible against anything in this repo — likely an artifact of the reporter's deployment tooling, not addressed here.

## Test plan
- [x] `cd controller && npm run lint && npm test` — 243 tests pass, including new `db/client.test.ts` and `notifications/__tests__/email.test.ts`
- [x] `cd ui && npm run lint && npm test` — 72 tests pass
- [x] `cd controller && npm run build` / `cd ui && npm run build` — both succeed
- [ ] Manually verify the corrected docs compose example against a real deploy
- [ ] Manually verify email delivery via the UI's "Test" button against a local SMTP catcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)