### PR TITLE
ci(pr-beta): isolate matrix failures and reduce GHA cache pressure

### DIFF
--- a/.github/workflows/pr-beta.yml
+++ b/.github/workflows/pr-beta.yml
@@ -74,6 +74,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         include:
           - service: controller
@@ -116,7 +117,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/watchwarden-${{ matrix.service }}:pr-${{ needs.check-permissions.outputs.pr_number }}-beta
             ghcr.io/${{ github.repository_owner }}/watchwarden-${{ matrix.service }}:sha-${{ needs.check-permissions.outputs.pr_sha }}
           cache-from: type=gha,scope=${{ matrix.service }}-pr
-          cache-to: type=gha,scope=${{ matrix.service }}-pr,mode=max
+          cache-to: type=gha,scope=${{ matrix.service }}-pr,mode=min
 
   comment:
     name: Post PR Comment


### PR DESCRIPTION
## Summary

- `strategy.fail-fast: false` on the `build-and-push` matrix job (`.github/workflows/pr-beta.yml`) — a failure in one service's build (controller/agent/ui) no longer cancels the other two mid-push, so a transient flake in one leg doesn't turn into a partial/incomplete beta release.
- `cache-to` mode changed from `mode=max` to `mode=min` — writes fewer cache blobs per multi-arch build, reducing the odds of hitting the GitHub Actions cache's `failed to reserve cache` write error.

## Context

Two consecutive `/pr-beta` runs on PR #74 failed the same way: the controller image build/push actually succeeded, then failed afterward at the `cache-to: type=gha` export step with:

```
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

Because the matrix used the default `fail-fast: true`, that failure cancelled the "Build agent" and "Build ui" jobs mid-push, so those images were never published for the PR's beta tag — which is why the beta deploy failed downstream.

This fix is split into its own PR (separate from #74) specifically so it can be merged and take effect on `main` immediately — workflows triggered by `issue_comment` (like `/pr-beta`) always run using the workflow YAML on the default branch, not the PR branch, so the fix has to land on `main` before any `/pr-beta` run can benefit from it.

## Test plan
- [x] Validated YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge, re-run `/pr-beta` on an open PR and confirm all three services (controller/agent/ui) build and push successfully even if one hits a transient cache error


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpswSanokduHMgmMJa9ndF)_