### PR TITLE
ci(pr-beta): stop writing to GHA cache to fix persistent build failures

### DIFF
--- a/.github/workflows/pr-beta.yml
+++ b/.github/workflows/pr-beta.yml
@@ -117,7 +117,6 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/watchwarden-${{ matrix.service }}:pr-${{ needs.check-permissions.outputs.pr_number }}-beta
             ghcr.io/${{ github.repository_owner }}/watchwarden-${{ matrix.service }}:sha-${{ needs.check-permissions.outputs.pr_sha }}
           cache-from: type=gha,scope=${{ matrix.service }}-pr
-          cache-to: type=gha,scope=${{ matrix.service }}-pr,mode=min
 
   comment:
     name: Post PR Comment


### PR DESCRIPTION
## Summary

- Removes `cache-to: type=gha,scope=${{ matrix.service }}-pr,mode=min` from the `Build and push` step in `.github/workflows/pr-beta.yml`, keeping `cache-from` (which is best-effort and doesn't fail the build on a cache miss).

## Context

This is a follow-up to #75. That PR added `fail-fast: false` and switched `cache-to` from `mode=max` to `mode=min` to address a `/pr-beta` failure caused by:

```
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

After #75 merged, `/pr-beta` was re-run on PR #74 (run [30886526264](https://github.com/watchwarden-labs/watchwarden/actions/runs/30886526264)):
- `fail-fast: false` worked as intended — "Build ui" kept running independently instead of being cancelled when the other two failed.
- But **both** "Build controller" and "Build agent" failed with the exact same `failed to reserve cache` error, even under `mode=min`. In one case the error interrupted the image push itself mid-flight (`#46 pushing layers 0.3s done` → `#46 CANCELED`).

Hitting the identical error on 2/2 builds, across two different services, right after reducing cache volume, points to the repo's GitHub Actions cache storage quota (10GB, shared across all scopes) being exhausted — likely backfilled by the historical `mode=max` caches written by every past `/pr-beta` run before #75. Reducing volume further wasn't enough; the only reliable fix is to stop writing to the GHA cache from this workflow entirely.

## Test plan
- [x] Validated YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge, re-run `/pr-beta` on an open PR and confirm all three services (controller/agent/ui) build and push successfully without hitting the cache-export error


---
_Generated by [Claude Code](https://claude.ai/code/session_01KpswSanokduHMgmMJa9ndF)_