### PR TITLE
Add agent token regeneration without deletion

### DIFF
--- a/agent/ws.go
+++ b/agent/ws.go
@@ -109,6 +109,14 @@ func (w *WSClient) ConnectionCtx() context.Context {
 	return context.Background()
 }
 
+// stableConnectionThreshold is how long a connection must stay up before we
+// treat it as healthy and reset the reconnect backoff. dial() only proves the
+// WS transport handshake succeeded — a controller that rejects REGISTER (e.g.
+// invalid AGENT_TOKEN) closes the socket within milliseconds, which otherwise
+// looks identical to a successful connection and would reset backoff to 1s on
+// every cycle, hammering the controller instead of backing off.
+const stableConnectionThreshold = 5 * time.Second
+
 // ConnectLoop runs the connection loop with reconnection logic.
 func (w *WSClient) ConnectLoop(ctx context.Context) {
 	backoff := 1 * time.Second
@@ -120,13 +128,16 @@ func (w *WSClient) ConnectLoop(ctx context.Context) {
 		default:
 		}
 
+		connectedAt := time.Now()
 		err := w.dial(ctx)
 		if err == nil {
-			backoff = 1 * time.Second // Reset on success
 			w.setConnected(true)
 			w.register()
 			w.readWriteLoop(ctx)
 			w.setConnected(false)
+			if time.Since(connectedAt) >= stableConnectionThreshold {
+				backoff = 1 * time.Second // Reset only after a genuinely stable connection
+			}
 		}
 
 		// Full-jitter: sleep = random_between(0, backoff) — RC-05.

--- a/controller/src/api/__tests__/agents.test.ts
+++ b/controller/src/api/__tests__/agents.test.ts
@@ -144,6 +144,36 @@ describe('agents API', () => {
     expect(getRes.statusCode).toBe(404);
   });
 
+  it('POST /api/agents/:id/regenerate-token returns 200 with a new token', async () => {
+    const regRes = await app.inject({
+      method: 'POST',
+      url: '/api/agents/register',
+      headers: authHeaders(),
+      payload: { name: 'Regen Agent', hostname: 'server-5' },
+    });
+    const { agentId, token: originalToken } = JSON.parse(regRes.body);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/agents/${agentId}/regenerate-token`,
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.agentId).toBe(agentId);
+    expect(typeof body.token).toBe('string');
+    expect(body.token).not.toBe(originalToken);
+  });
+
+  it('POST /api/agents/:unknown/regenerate-token returns 404', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/agents/nonexistent-id/regenerate-token',
+      headers: authHeaders(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
   it('PUT /api/agents/:id/config updates schedule and auto_update', async () => {
     const regRes = await app.inject({
       method: 'POST',

--- a/controller/src/api/middleware/audit.ts
+++ b/controller/src/api/middleware/audit.ts
@@ -14,6 +14,10 @@ const AUDIT_ROUTES: Record<string, { action: string; targetType: string }> = {
     targetType: 'agent',
   },
   'DELETE /api/agents/:id': { action: 'agent.delete', targetType: 'agent' },
+  'POST /api/agents/:id/regenerate-token': {
+    action: 'agent.regenerate_token',
+    targetType: 'agent',
+  },
   'POST /api/agents/:id/check': { action: 'agent.check', targetType: 'agent' },
   'POST /api/agents/:id/update': {
     action: 'container.update',

--- a/controller/src/api/routes/agents.ts
+++ b/controller/src/api/routes/agents.ts
@@ -12,6 +12,7 @@ import {
   insertAgent,
   listAgents,
   updateAgentConfig,
+  updateAgentToken,
   updateContainerOrchestration,
   updateContainerPolicy,
 } from '../../db/queries.js';
@@ -92,6 +93,34 @@ const agentsRoutes: FastifyPluginAsync = async (fastify) => {
     await deleteAgent(request.params.id);
     return reply.code(204).send();
   });
+
+  // Issue a new token for an existing agent without deleting it — recovers a
+  // lost/stale/rotated AGENT_TOKEN without cascading away the agent's container
+  // history, update log, and policies (which DELETE /api/agents/:id would).
+  // The old token stops authenticating new connections immediately; an
+  // already-connected agent keeps its current session until it next reconnects.
+  fastify.post<{ Params: { id: string } }>(
+    '/api/agents/:id/regenerate-token',
+    {
+      config: {
+        rateLimit: {
+          max: 10,
+          timeWindow: '1 minute',
+        },
+      },
+    },
+    async (request, reply) => {
+      const agent = await getAgent(request.params.id);
+      if (!agent) {
+        return reply.code(404).send({ error: 'Agent not found' });
+      }
+      const rawToken = randomBytes(32).toString('hex');
+      const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+      const tokenPrefix = rawToken.slice(0, 8);
+      await updateAgentToken(request.params.id, tokenHash, tokenPrefix);
+      return reply.code(200).send({ agentId: agent.id, token: rawToken });
+    },
+  );
 
   // Check all online agents — batches notifications into a single dispatch.
   // MUST be registered before /:id/check to avoid Fastify matching "check-all" as an :id param.

--- a/controller/src/db/queries.ts
+++ b/controller/src/db/queries.ts
@@ -85,6 +85,14 @@ export async function deleteAgent(id: string): Promise<void> {
   await sql`DELETE FROM agents WHERE id = ${id}`;
 }
 
+export async function updateAgentToken(
+  id: string,
+  tokenHash: string,
+  tokenPrefix: string,
+): Promise<void> {
+  await sql`UPDATE agents SET token_hash = ${tokenHash}, token_prefix = ${tokenPrefix} WHERE id = ${id}`;
+}
+
 // --- Containers ---
 
 export async function upsertContainers(

--- a/controller/src/ws/__tests__/hub.test.ts
+++ b/controller/src/ws/__tests__/hub.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import fastifyWebsocket from '@fastify/websocket';
 import bcrypt from 'bcryptjs';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -11,6 +12,7 @@ import {
   insertAgent,
   listAgents,
   setConfig,
+  updateAgentToken,
 } from '../../db/queries.js';
 import { AgentHub } from '../hub.js';
 
@@ -129,6 +131,46 @@ describe('AgentHub', () => {
 
     const { code } = await closePromise;
     expect(code).toBe(4001);
+  });
+
+  it('regenerating an agent token rejects the old token and accepts the new one', async () => {
+    const newRawToken = 'regenerated-token-abc123';
+    const newTokenHash = createHash('sha256').update(newRawToken).digest('hex');
+    await updateAgentToken('hub-agent-1', newTokenHash, newRawToken.slice(0, 8));
+
+    // Old token no longer authenticates.
+    const oldWs = connectAgent();
+    await waitForOpen(oldWs);
+    const oldClosePromise = waitForClose(oldWs);
+    oldWs.send(
+      JSON.stringify({
+        type: 'REGISTER',
+        payload: { token: agentToken, hostname: 'server-1', containers: [] },
+      }),
+    );
+    const { code } = await oldClosePromise;
+    expect(code).toBe(4001);
+
+    // New token authenticates and brings the agent online.
+    const newWs = connectAgent();
+    await waitForOpen(newWs);
+    newWs.send(
+      JSON.stringify({
+        type: 'REGISTER',
+        payload: { token: newRawToken, hostname: 'server-1', containers: [] },
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 200));
+
+    const agent = await getAgent('hub-agent-1');
+    expect(agent?.status).toBe('online');
+
+    newWs.close();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Restore the original bcrypt-hashed token for subsequent tests in this file.
+    const restoredHash = await bcrypt.hash(agentToken, 10);
+    await updateAgentToken('hub-agent-1', restoredHash, agentToken.slice(0, 8));
   });
 
   it('agent sends non-REGISTER first message closes socket', async () => {

--- a/controller/src/ws/hub.ts
+++ b/controller/src/ws/hub.ts
@@ -182,6 +182,10 @@ export class AgentHub {
 
           if (!authenticated) {
             if (message.type !== 'REGISTER') {
+              log.warn(
+                'hub',
+                `Rejected WS connection: first message was "${message.type}", expected REGISTER`,
+              );
               socket.close(4002, 'First message must be REGISTER');
               return;
             }
@@ -195,6 +199,10 @@ export class AgentHub {
             }
 
             if (!result) {
+              log.warn(
+                'hub',
+                `Rejected agent REGISTER: invalid token (agentName=${payload.agentName ?? 'unknown'}, hostname=${payload.hostname ?? 'unknown'})`,
+              );
               socket.close(4001, 'Invalid token');
               return;
             }
@@ -202,7 +210,7 @@ export class AgentHub {
             agentId = result.id;
             authenticated = true;
             clearTimeout(authTimeout);
-            log.debug('hub', `Agent registered: ${payload.agentName ?? agentId}`, {
+            log.info('hub', `Agent registered: ${payload.agentName ?? agentId}`, {
               version: payload.version,
               containers: payload.containers?.length,
             });

--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -17,6 +17,15 @@ export class ApiError extends Error {
   }
 }
 
+/** Extracts the server's `{ error: string }` reason from a failed apiRequest, falling back otherwise. */
+export function apiErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) {
+    const reason = (err.body as { error?: string } | undefined)?.error;
+    if (reason) return reason;
+  }
+  return fallback;
+}
+
 export async function apiRequest<T>(path: string, options?: RequestInit): Promise<T> {
   // Always include credentials so the httpOnly cookie is forwarded.
   // Also send Authorization: Bearer as fallback for API clients that stored the token.

--- a/ui/src/api/hooks/useAgents.ts
+++ b/ui/src/api/hooks/useAgents.ts
@@ -32,6 +32,15 @@ export function useRegisterAgent() {
   });
 }
 
+export function useRegenerateAgentToken() {
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiRequest<{ agentId: string; token: string }>(`/agents/${id}/regenerate-token`, {
+        method: 'POST',
+      }),
+  });
+}
+
 export function useDeleteAgent() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/ui/src/components/agents/ContainerRow.tsx
+++ b/ui/src/components/agents/ContainerRow.tsx
@@ -16,6 +16,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { apiErrorMessage } from '@/api/client';
 import {
   type Container,
   useCheckContainer,
@@ -291,10 +292,7 @@ export function ContainerRow({ agentId, container, onUpdate }: ContainerRowProps
         onSuccess: () => addToast({ type: 'info', message: `Checking ${container.name}...` }),
         onError: (err) => {
           setPendingAction(null);
-          addToast({
-            type: 'error',
-            message: `Check failed: ${err instanceof Error ? err.message : String(err)}`,
-          });
+          addToast({ type: 'error', message: apiErrorMessage(err, 'Check failed') });
         },
       },
     );

--- a/ui/src/components/agents/RegenerateTokenModal.tsx
+++ b/ui/src/components/agents/RegenerateTokenModal.tsx
@@ -1,0 +1,138 @@
+import { Check, Copy } from 'lucide-react';
+import { useState } from 'react';
+import { apiErrorMessage } from '@/api/client';
+import { useRegenerateAgentToken } from '@/api/hooks/useAgents';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { useStore } from '@/store/useStore';
+
+interface RegenerateTokenModalProps {
+  agentId: string;
+  agentName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function RegenerateTokenModal({
+  agentId,
+  agentName,
+  open,
+  onOpenChange,
+}: RegenerateTokenModalProps) {
+  const [token, setToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const regenerateToken = useRegenerateAgentToken();
+  const addToast = useStore((s) => s.addToast);
+
+  const handleRegenerate = () => {
+    regenerateToken.mutate(agentId, {
+      onSuccess: (data) => setToken(data.token),
+      onError: (err) =>
+        addToast({ type: 'error', message: apiErrorMessage(err, 'Failed to regenerate token') }),
+    });
+  };
+
+  const handleCopy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // Fallback for non-HTTPS contexts (e.g. http://192.168.x.x)
+      const textarea = document.createElement('textarea');
+      textarea.value = text;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const resetAndClose = () => {
+    setToken(null);
+    setCopied(false);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (next ? onOpenChange(next) : resetAndClose())}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {token ? 'Token Regenerated' : `Regenerate Token for ${agentName}`}
+          </DialogTitle>
+          <DialogDescription>
+            {token
+              ? 'Save the new token below — it will only be shown once.'
+              : 'The current token will stop working immediately. The agent will show offline until AGENT_TOKEN is updated on the target host and the container is restarted.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {token && (
+          <div className="space-y-4 py-2">
+            <Card>
+              <CardContent className="pt-4 space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <Label className="text-xs text-muted-foreground">New Agent Token</Label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs"
+                    onClick={() => handleCopy(token)}
+                  >
+                    {copied ? (
+                      <>
+                        <Check size={12} className="text-success" data-icon="inline-start" /> Copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy size={12} data-icon="inline-start" /> Copy
+                      </>
+                    )}
+                  </Button>
+                </div>
+                <code className="block bg-background p-2.5 rounded font-mono text-sm text-primary break-all select-all">
+                  {token}
+                </code>
+              </CardContent>
+            </Card>
+            <p className="text-xs text-muted-foreground">
+              Update <code className="font-mono">AGENT_TOKEN</code> in the agent's environment on{' '}
+              {agentName} and restart the container to reconnect.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {!token ? (
+            <>
+              <Button variant="ghost" onClick={resetAndClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleRegenerate}
+                disabled={regenerateToken.isPending}
+              >
+                {regenerateToken.isPending ? 'Regenerating...' : 'Regenerate Token'}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={resetAndClose}>Done</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1,5 +1,15 @@
 import { formatDistanceToNow } from 'date-fns';
-import { Box, Info, Loader2, RefreshCw, RotateCw, Scissors, Shield, Trash2 } from 'lucide-react';
+import {
+  Box,
+  Info,
+  KeyRound,
+  Loader2,
+  RefreshCw,
+  RotateCw,
+  Scissors,
+  Shield,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { apiErrorMessage } from '@/api/client';
@@ -14,6 +24,7 @@ import {
 } from '@/api/hooks/useAgents';
 import { useUpdatePolicy, useUpdatePolicyMutation } from '@/api/hooks/usePolicies';
 import { ContainerRow } from '@/components/agents/ContainerRow';
+import { RegenerateTokenModal } from '@/components/agents/RegenerateTokenModal';
 import { CronPicker } from '@/components/common/CronPicker';
 import { Pagination } from '@/components/common/Pagination';
 import { StatusDot } from '@/components/common/StatusDot';
@@ -53,6 +64,7 @@ export function AgentDetail() {
   const isChecking = agent ? checkingAgents.has(agent.id) : false;
   const [pruneKeep, setPruneKeep] = useState(1);
   const [pruneConfirmOpen, setPruneConfirmOpen] = useState(false);
+  const [regenerateTokenOpen, setRegenerateTokenOpen] = useState(false);
   const [showStopped, setShowStopped] = useState(
     () => localStorage.getItem('showStopped') === 'true',
   );
@@ -117,12 +129,24 @@ export function AgentDetail() {
             )}
           </div>
         </div>
-        {agent.status === 'offline' && (
-          <Button variant="destructive" size="sm" onClick={handleDelete}>
-            <Trash2 size={14} data-icon="inline-start" /> Remove Agent
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => setRegenerateTokenOpen(true)}>
+            <KeyRound size={14} data-icon="inline-start" /> Regenerate Token
           </Button>
-        )}
+          {agent.status === 'offline' && (
+            <Button variant="destructive" size="sm" onClick={handleDelete}>
+              <Trash2 size={14} data-icon="inline-start" /> Remove Agent
+            </Button>
+          )}
+        </div>
       </div>
+
+      <RegenerateTokenModal
+        agentId={agent.id}
+        agentName={agent.name}
+        open={regenerateTokenOpen}
+        onOpenChange={setRegenerateTokenOpen}
+      />
 
       <Tabs defaultValue="containers">
         <TabsList>

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -2,6 +2,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { Box, Info, Loader2, RefreshCw, RotateCw, Scissors, Shield, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
+import { apiErrorMessage } from '@/api/client';
 import {
   useAgent,
   useCheckAgent,
@@ -167,9 +168,9 @@ export function AgentDetail() {
                         type: 'info',
                         message: 'Checking for updates...',
                       }),
-                    onError: () => {
+                    onError: (err) => {
                       setAgentChecking(agent.id, false);
-                      addToast({ type: 'error', message: 'Check failed' });
+                      addToast({ type: 'error', message: apiErrorMessage(err, 'Check failed') });
                     },
                   });
                 }}

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -1,6 +1,7 @@
 import { Hexagon, LayoutGrid, List, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router';
+import { apiErrorMessage } from '@/api/client';
 import { useAgents, useCheckAgent, useDeleteAgent, useUpdateAgent } from '@/api/hooks/useAgents';
 import { AgentCard } from '@/components/agents/AgentCard';
 import { AgentListRow } from '@/components/agents/AgentListRow';
@@ -35,7 +36,10 @@ export function Agents() {
     if (checkingAgents.has(agentId)) return;
     setAgentChecking(agentId, true);
     checkAgent.mutate(agentId, {
-      onError: () => setAgentChecking(agentId, false),
+      onError: (err) => {
+        setAgentChecking(agentId, false);
+        addToast({ type: 'error', message: apiErrorMessage(err, 'Check failed') });
+      },
     });
   };
 


### PR DESCRIPTION
## Summary
Adds the ability to regenerate an agent's authentication token without deleting the agent itself. This allows recovery of lost/stale/rotated tokens while preserving the agent's container history, update logs, and policies.

## Key Changes

**Backend (Controller)**
- New `POST /api/agents/:id/regenerate-token` endpoint that issues a new token and invalidates the old one
- New `updateAgentToken()` database query to update token hash and prefix
- Added audit logging for token regeneration actions
- Enhanced WebSocket hub logging for authentication failures and successful registrations
- New test coverage for token regeneration flow

**Agent (Go)**
- Improved reconnection backoff logic with `stableConnectionThreshold` (5s) to prevent hammering the controller when authentication fails
- Only resets backoff to 1s after a genuinely stable connection, not immediately after dial succeeds
- Prevents rapid reconnection loops when AGENT_TOKEN is invalid

**Frontend (UI)**
- New `RegenerateTokenModal` component for the token regeneration workflow
- Displays the new token once with copy-to-clipboard functionality
- Added "Regenerate Token" button to agent detail page
- Improved error handling with `apiErrorMessage()` utility for extracting server error reasons
- New `useRegenerateAgentToken()` hook for the API call

**Database**
- New `updateAgentToken()` query function to update token_hash and token_prefix columns

## Implementation Details

- The old token stops authenticating new connections immediately; already-connected agents keep their session until reconnection
- New tokens are generated as 32-byte hex strings with an 8-character prefix stored separately
- Token hashes use SHA-256 (matching the new token format), while existing tokens use bcrypt
- Rate-limited to 10 requests per minute to prevent abuse
- Comprehensive test coverage including WebSocket authentication flow with old vs. new tokens

Resolving #78 
